### PR TITLE
Fix add_soup: Content-Type might not be present

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -8,7 +8,8 @@ class Browser:
 
     @staticmethod
     def add_soup(response):
-        if 'text/html' in response.headers['Content-Type']:
+        if 'Content-Type' in response.headers \
+                and 'text/html' in response.headers['Content-Type']:
             try:
                 response.soup = bs4.BeautifulSoup(response.content)
             except:


### PR DESCRIPTION
In some cases, headers might not contain key 'Content-Type'.  Therefore
first check if key is present before getting its value.
