### PR TITLE
.codecov.yml: disable PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
-comment:
-  require_changes: true
+# Don't post a comment on pull requests
+comment: off


### PR DESCRIPTION
The Codecov PR comments are too verbose and do not add anything that
the Codecov GitHub App does not provide in the integrated checks.