### PR TITLE
README.md: more precise python version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Installation
 ------
 
 [![Latest Version](https://img.shields.io/pypi/v/MechanicalSoup.svg)](https://pypi.python.org/pypi/MechanicalSoup/)
+[![Supported Versions](https://img.shields.io/pypi/pyversions/mechanicalsoup.svg)](https://pypi.python.org/pypi/MechanicalSoup/)
 
 From [PyPI](https://pypi.python.org/pypi/MechanicalSoup/)
 
      pip install MechanicalSoup
 
-Python versions 2.7, 3.4-3.6, PyPy and PyPy3 are supported (and tested against).
+PyPy and PyPy3 are also supported (and tested against).
 
 Example
 ------
@@ -93,6 +94,8 @@ Development
 [![Build Status](https://travis-ci.org/MechanicalSoup/MechanicalSoup.svg?branch=master)](https://travis-ci.org/MechanicalSoup/MechanicalSoup)
 [![Coverage Status](https://codecov.io/gh/MechanicalSoup/MechanicalSoup/branch/master/graph/badge.svg)](https://codecov.io/gh/MechanicalSoup/MechanicalSoup)
 [![Requirements Status](https://requires.io/github/MechanicalSoup/MechanicalSoup/requirements.svg?branch=master)](https://requires.io/github/MechanicalSoup/MechanicalSoup/requirements/?branch=master)
+
+Python version support in the current master branch may differ from the latest release in [PyPI](https://pypi.python.org/pypi/MechanicalSoup/). Please inspect `.travis.yml` or run `python setup.py --classifiers` to see which versions of Python are supported in the current master branch.
 
 Installing dependencies and running tests can be done with:
 


### PR DESCRIPTION
Use the PyPI badge to display which Python versions are supported in
the latest PyPI release version. Previously, Python version support
identified the version supported in the current master branch, but
these two are not necessarily the same.

Provide instructions for developers to see the Python version support
in the current master branch so that we do not need to hard-code the
version list in more places (it's already hard-coded in two places:
`setup.py` and `.travis.yml`).

NOTE: I'm open to hard-coding this list in the README instead of providing a programmatic method if you think it would be more useful. We'll just need to be vigilant about desync. :)