### PR TITLE
browser.py: don't except AttributeError in set_user_agent

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -49,13 +49,8 @@ class Browser(object):
     def set_user_agent(self, user_agent):
         # set a default user_agent if not specified
         if user_agent is None:
-            try:
-                requests_ua = requests.utils.default_user_agent()
-            except AttributeError:
-                user_agent = '%s/%s' % (__title__, __version__)
-            else:
-                user_agent = '%s (%s/%s)' % (
-                    requests_ua, __title__, __version__)
+            requests_ua = requests.utils.default_user_agent()
+            user_agent = '%s (%s/%s)' % (requests_ua, __title__, __version__)
 
         # the requests module uses a case-insensitive dict for session headers
         self.session.headers['User-agent'] = user_agent


### PR DESCRIPTION
The AttributeError except was implemented for versions of `requests`
that did not have a `utils.default_user_agent` method. However, we
require `requests >= 2.0`. Since this method exists in the minimum
required version (2.0), there is no need to keep this exception.

NOTE: Please reject this PR if it is important to handle possible `AttributeError` exceptions _within the implementation_ of `requests.utils.default_user_agent`. While this method existed in v2.0, it still called methods and members of other modules until v2.8.0 (at which point it became a trivial method with no possibility of an `AttributeError`), which could in principle raise an `AttributeError`. For unimpeachable safety, keep the code as-is and reject the PR until we require `requests >= 2.8.0`.