### PR TITLE
add .mention-bot configuration file

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,3 @@
+{
+  "userBlacklist": ["moy", "hemberger", "hickford"] // Users in this list will never be mentioned by mention-bot
+}


### PR DESCRIPTION
I suggest we enable the [mention bot](https://github.com/facebook/mention-bot) to ping contributors when a PR modifies their code. The goal is to encourage occasional contributors to come back in the discussion when their code is modified. 

We don't want to spam hickford, who wrote large parts of the code but is less active these days, nor moy and hemberget who are already watching the project anyway, so this PR adds a blacklist to avoid this.

Opinions?