### PR TITLE
Switch to requirements.txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ and `*.rst` documentation files in the `docs/` directory.
 You can develop against multiple versions of Python using [virtualenv](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments):
 
     python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
-    pip install bs4 pytest pytest-cov pytest-flake8 pytest-mock requests_mock
+    pip install -r requirements.txt -r tests/requirements.txt
 and
 
     virtualenv -p python2 --no-site-packages .virtual-py2 && source .virtual-py2/bin/activate
-    pip install bs4 pytest pytest-cov pytest-flake8 pytest-mock requests_mock
+    pip install -r requirements.txt -r tests/requirements.txt
 
 After making changes, run pytest in all virtualenvs:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests >= 2.0
+beautifulsoup4
+six >= 1.4

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@ from setuptools import setup  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
 from os import path
 
+
+def requirements_from_file(filename):
+    """Parses a pip requirements file into a list."""
+    return [line.strip() for line in open(filename, 'r')
+            if line.strip() and not line.strip().startswith('--')]
+
+
 here = path.abspath(path.dirname(__file__))
 
 about = {}
@@ -40,19 +47,7 @@ setup(
     # when your project is installed. For an analysis of
     # "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[
-        'requests >= 2.0',
-        'beautifulsoup4',
-        'six >= 1.4'
-    ],
-    setup_requires=[
-        'pytest-runner',
-    ],
-    tests_require=[
-        'pytest',
-        'pytest-cov',
-        'pytest-flake8',
-        'pytest-mock',
-        'requests_mock'
-    ]
+    install_requires=requirements_from_file('requirements.txt'),
+    setup_requires=['pytest-runner'],
+    tests_require=requirements_from_file('tests/requirements.txt'),
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+pytest-flake8
+pytest-mock
+requests_mock


### PR DESCRIPTION
Addresses issue #109.

Move install and test dependencies out of `setup.py` and into
`requirements.txt` and `tests/requirements.txt` respectively.

To avoid duplicating the list of dependencies, we read these
files in `setup.py` to build the `install_requires` and
`tests_require` lists.

In the development workflow instructions, we can recommend
installing all dependencies with pip using these files to avoid
yet another place where the list of dependencies would otherwise
be duplicated.