### PR TITLE
form.py: refactor set method

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -26,6 +26,16 @@ Main changes:
 
     pip install -r requirements.txt -r tests/requirements.txt
 
+* The ``Form`` class was restructured and has a new API. The behavior of
+  existing code is unchanged, but a new collection of methods has been
+  added for clarity and consistency with the ``set`` method:
+
+  - ``set_input`` deprecates ``input``
+  - ``set_textarea`` deprecates ``textarea``
+  - ``set_select`` is new
+  - ``set_checkbox`` and ``set_radio`` together deprecate ``check``
+    (checkboxes are handled differently by default)
+
 Bug fixes
 ---------
 

--- a/mechanicalsoup/__init__.py
+++ b/mechanicalsoup/__init__.py
@@ -1,8 +1,8 @@
 from .utils import LinkNotFoundError
 from .browser import Browser
-from .form import Form
+from .form import Form, InvalidFormMethod
 from .stateful_browser import StatefulBrowser
 from .__version__ import __version__
 
 __all__ = ['StatefulBrowser', 'LinkNotFoundError', 'Browser', 'Form',
-           '__version__']
+           'InvalidFormMethod', '__version__']

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -2,113 +2,226 @@ from .utils import LinkNotFoundError
 from bs4 import BeautifulSoup
 
 
+class InvalidFormMethod(LinkNotFoundError):
+    """This exception is raised when a method of :class:`Form` is used
+    for an HTML element that is of the wrong type (or is malformed).
+    It is caught within :func:`Form.set` to perform element type deduction.
+
+    It is derived from :class:`LinkNotFoundError` so that a single base class
+    can be used to catch all exceptions specific to this module.
+    """
+    pass
+
+
 class Form(object):
+    """The Form class is responsible for preparing HTML forms for submission.
+    It handles the following types of elements:
+    input (text, checkbox, radio), select, and textarea.
+
+    Each type is set by a method named after the type (e.g.
+    :func:`~Form.set_select`), and then there are convenience methods (e.g.
+    :func:`~Form.set`) that do type-deduction and set the value using the
+    appropriate method.
+
+    It also handles submit-type elements using :func:`~Form.choose_submit`.
+    """
 
     def __init__(self, form):
         self.form = form
 
-    def input(self, data):
+    def set_input(self, data):
         """Fill-in a set of fields in a form.
 
         Example: filling-in a login/password form
 
         .. code-block:: python
 
-           form.input({"login": username, "password": password})
+           form.set_input({"login": username, "password": password})
 
         This will find the input element named "login" and give it the
         value ``username``, and the input element named "password" and
         give it the value ``password``.
-
-        The type of element (input, textarea, select, ...) does not
-        need to be given.
         """
 
         for (name, value) in data.items():
             i = self.form.find("input", {"name": name})
             if not i:
-                raise LinkNotFoundError("No input field named " + name)
+                raise InvalidFormMethod("No input field named " + name)
             i["value"] = value
 
-    attach = input
-
     def uncheck_all(self, name):
+        """Remove the *checked*-attribute of all input elements with
+        a *name*-attribute given by ``name``.
+        """
         for option in self.form.find_all("input", {"name": name}):
             if "checked" in option.attrs:
                 del option.attrs["checked"]
 
     def check(self, data):
+        """For backwards compatibility, this method handles checkboxes
+        and radio buttons in a single call. It will not uncheck any
+        checkboxes unless explicitly specified by ``data``, in contrast
+        with the default behavior of :func:`~Form.set_checkbox`.
+        """
         for (name, value) in data.items():
-            # Complain if we don't find the name, regardless of the
-            # value
-            inputs = self.form.find_all("input", {"name": name})
-            if inputs == []:
-                raise LinkNotFoundError("No input checkbox named " + name)
-            type = inputs[0].attrs.get('type', 'text')
-            if type == "radio":
+            try:
+                self.set_checkbox({name: value}, uncheck_other_boxes=False)
+                continue
+            except InvalidFormMethod:
+                pass
+            try:
+                self.set_radio({name: value})
+                continue
+            except InvalidFormMethod:
+                pass
+            raise LinkNotFoundError("No input checkbox/radio named " + name)
+
+    def set_checkbox(self, data, uncheck_other_boxes=True):
+        """Set the *checked*-attribute of input elements of type "checkbox"
+        specified by ``data`` (i.e. check boxes).
+
+        :param data: Dict of ``{name: value, ...}``.
+            In the family of checkboxes whose *name*-attribute is ``name``,
+            check the box whose *value*-attribute is ``value``. All boxes in
+            the family can be checked (unchecked) if ``value`` is True (False).
+            To check multiple specific boxes, let ``value`` be a tuple or list.
+        :param uncheck_other_boxes: If True (default), before checking any
+            boxes specified by ``data``, uncheck the entire checkbox family.
+            Consider setting to False if some boxes are checked by default when
+            the HTML is served.
+        """
+        for (name, value) in data.items():
+            checkboxes = self.form.find_all("input", {"name": name},
+                                            type="checkbox")
+            if not checkboxes:
+                raise InvalidFormMethod("No input checkbox named " + name)
+
+            # uncheck if requested
+            if uncheck_other_boxes:
                 self.uncheck_all(name)
 
-            # Accept individual values (int, str)
-            # We just wrap them in a 1-value tuple.
+            # Wrap individual values (e.g. int, str) in a 1-element tuple.
             if not isinstance(value, list) and not isinstance(value, tuple):
                 value = (value,)
+
+            # Check or uncheck one or more boxes
             for choice in value:
-                choice = str(choice)  # Allow for example literal numbers
-                for i in inputs:
-                    if i.attrs.get("value", "on") == choice:
-                        i["checked"] = ""
+                choice_str = str(choice)  # Allow for example literal numbers
+                for checkbox in checkboxes:
+                    if checkbox.attrs.get("value", "on") == choice_str:
+                        checkbox["checked"] = ""
+                        break
+                    # Allow specifying True or False to check/uncheck
+                    elif choice is True:
+                        checkbox["checked"] = ""
+                        break
+                    elif choice is False:
+                        if "checked" in checkbox.attrs:
+                            del checkbox.attrs["checked"]
                         break
                 else:
-                    print(self.form)
                     raise LinkNotFoundError(
                         "No input checkbox named %s with choice %s" %
                         (name, choice)
                     )
 
-    def textarea(self, data):
+    def set_radio(self, data):
+        """Set the *checked*-attribute of input elements of type "radio"
+        specified by ``data`` (i.e. select radio buttons).
+
+        :param data: Dict of ``{name: value, ...}``.
+            In the family of radio buttons whose *name*-attribute is ``name``,
+            check the radio button whose *value*-attribute is ``value``.
+            Only one radio button in the family can be checked.
+        """
+        for (name, value) in data.items():
+            radios = self.form.find_all("input", {"name": name}, type="radio")
+            if not radios:
+                raise InvalidFormMethod("No input radio named " + name)
+
+            # only one radio button can be checked
+            self.uncheck_all(name)
+
+            # Check the appropriate radio button (value cannot be a list/tuple)
+            for radio in radios:
+                if radio.attrs.get("value", "on") == str(value):
+                    radio["checked"] = ""
+                    break
+            else:
+                raise LinkNotFoundError(
+                    "No input radio named %s with choice %s" % (name, value)
+                )
+
+    def set_textarea(self, data):
+        """Set the *string*-attribute of the first textarea element
+        specified by ``data`` (i.e. set the text of a textarea).
+
+        :param data: Dict of ``{name: value, ...}``.
+            The textarea whose *name*-attribute is ``name`` will have
+            its *string*-attribute set to ``value``.
+        """
         for (name, value) in data.items():
             t = self.form.find("textarea", {"name": name})
             if not t:
-                raise LinkNotFoundError("No textarea named " + name)
+                raise InvalidFormMethod("No textarea named " + name)
             t.string = value
 
-    def __setitem__(self, name, value):
-        return self.set(name, value)
+    def set_select(self, data):
+        """Set the *selected*-attribute of the first option element
+        specified by ``data`` (i.e. select an option from a dropdown).
 
-    def set(self, name, value, force=False):
-        input = self.form.find("input", {"name": name})
-        if input:
-            if input.attrs.get('type', 'text') in ("radio", "checkbox"):
-                if value is True:
-                    # f["foo"] = True checks the box foo
-                    input.attrs["checked"] = ""
-                elif value is False:
-                    # f["foo"] = False unchecks it
-                    if "checked" in input.attrs:
-                        del input.attrs["checked"]
-                else:
-                    if isinstance(value, list) or isinstance(value, tuple):
-                        self.uncheck_all(name)
-                    self.check({name: value})
-            else:
-                input["value"] = value
-            return
-        textarea = self.form.find("textarea", {"name": name})
-        if textarea:
-            textarea.string = value
-            return
-        select = self.form.find("select", {"name": name})
-        if select:
+        :param data: Dict of ``{name: value, ...}``.
+            Find the select element whose *name*-attribute is ``name``.
+            Then select from among its children the option element whose
+            *value*-attribute is ``value``.
+        """
+        for (name, value) in data.items():
+            select = self.form.find("select", {"name": name})
+            if not select:
+                raise InvalidFormMethod("No select named " + name)
             for option in select.find_all("option"):
                 if "selected" in option.attrs:
                     del option.attrs["selected"]
             o = select.find("option", {"value": value})
             o.attrs["selected"] = "selected"
-            return
+
+    def __setitem__(self, name, value):
+        """Forwards arguments to :func:`~Form.set`. For example,
+        :code:`form["name"] = "value"` calls :code:`form.set("name", "value")`.
+        """
+        return self.set(name, value)
+
+    def set(self, name, value, force=False):
+        """Set a form element identified by ``name`` to a specified ``value``.
+        The type of element (input, textarea, select, ...) does not
+        need to be given; it is inferred by the following methods:
+        :func:`~Form.set_checkbox`,
+        :func:`~Form.set_radio`,
+        :func:`~Form.set_input`,
+        :func:`~Form.set_textarea`,
+        :func:`~Form.set_select`.
+        If none of these methods find a matching element, then if ``force``
+        is True, a new element will be added using :func:`~Form.new_control`.
+
+        Example: filling-in a login/password form with EULA checkbox
+
+        .. code-block:: python
+
+            form.set("login", username)
+            form.set("password", password)
+            form.set("eula-checkbox", True)
+
+        """
+        for func in ("checkbox", "radio", "input", "textarea", "select"):
+            try:
+                getattr(self, "set_" + func)({name: value})
+                return
+            except InvalidFormMethod:
+                pass
         if force:
             self.new_control('input', name, value=value)
             return
-        raise LinkNotFoundError()
+        raise LinkNotFoundError("No valid element named " + name)
 
     def new_control(self, type, name, value, **kwargs):
         old_input = self.form.find_all('input', {'name': name})
@@ -162,3 +275,8 @@ class Form(object):
             raise LinkNotFoundError(
                 "Specified submit element not found: {0}".format(el)
             )
+
+    # Aliases for backwards compatibility
+    attach = set_input
+    input = set_input
+    textarea = set_textarea

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -29,6 +29,12 @@ class Form(object):
     def __init__(self, form):
         self.form = form
 
+        # Aliases for backwards compatibility
+        # (Included specifically in __init__ to suppress them in Sphinx docs)
+        self.attach = self.set_input
+        self.input = self.set_input
+        self.textarea = self.set_textarea
+
     def set_input(self, data):
         """Fill-in a set of fields in a form.
 
@@ -275,8 +281,3 @@ class Form(object):
             raise LinkNotFoundError(
                 "Specified submit element not found: {0}".format(el)
             )
-
-    # Aliases for backwards compatibility
-    attach = set_input
-    input = set_input
-    textarea = set_textarea

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -262,6 +262,9 @@ page_with_missing_elements = '''
      <p><label> <input type=checkbox name="topping" value="onion" checked> Onion </label></p>
      <p><label> <input type=checkbox name="topping" value="mushroom"> Mushroom </label></p>
     </fieldset>
+    <input type=radio name="size" value="small">
+    <input type=radio name="size" value="medium">
+    <input type=radio name="size" value="large">
     <input type="submit" value="Select" />
   </form>
 </html>
@@ -280,6 +283,8 @@ def test_form_not_found():
         form.check({'topping': 'tofu'})
     with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
         form.textarea({'bar': 'value', 'foo': 'nosuchval'})
+    with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+        form.set_radio({'size': 'tiny'})
 
 page_with_radio = '''
 <html>
@@ -293,9 +298,12 @@ def test_form_check_uncheck():
     browser.open_fake_page(page_with_radio, url="http://example.com/invalid/")
     form = browser.select_form('form')
     assert "checked" not in form.form.find("input", {"name": "foo"}).attrs
+
     form["foo"] = True
     assert form.form.find("input", {"name": "foo"}).attrs["checked"] == ""
-    form["foo"] = False
+
+    # Test explicit unchecking (skipping the call to Form.uncheck_all)
+    form.set_checkbox({"foo": False}, uncheck_other_boxes=False)
     assert "checked" not in form.form.find("input", {"name": "foo"}).attrs
 
 


### PR DESCRIPTION
Instead of having Form.set implement textarea/check/select/input
itself, call the methods that already implement these. This change
reduces code duplication and prevents the two implementations
from getting out of sync (which had already happened with Form.check).

A new exception InvalidFormMethod is derived from LinkNotFoundError
and used in the methods called by Form.set to catch when the method
doesn't apply to the particular element being set. This is how
Form.set does its element type deduction now.

All methods called from Form.set are now prefixed with "set_".

Form.set
  * Is now a wrapper around Form.set_*.
  * Retains its original behavior.

Form.check
  * Is now a wrapper around Form.set_{checkbox,radio}.
  * Retains its original behavior for backwards compatibility, even
    though its handling of checkboxes is different than Form.set.

Form.set_radio
  * Factored out of Form.check.
  * Split into its own method because the design for radios is
    sufficiently different (and less complicated) than checkboxes
    that it warrants its own function for clarity.

Form.set_checkbox
  * Factored out of Form.check to implement new behavior that is
    consistent with Form.set.
  * Provides a "uncheck_others" argument to improve clarity about
    how it handles unspecified boxes. Form.set uses the default
    (True) and Form.check uses False (for backwards compatibility).
    The behavior in Form.set only changed recently (fc98922b94f67).
  * Implements the True/False values previously in Form.set but
    not in Form.check.

Form.set_select
  * Factored out of Form.set

Form.set_input
  * Renamed from Form.input (which is now an alias).

Form.set_textarea
  * Renamed from Form.textarea (which is now an alias).

The aliases and Form.check should be deprecated.

____________________________________________
TODO items:
- [x] better name for InvalidFormMethod exception
- [x] add tests of untested set_radio branches
- [x] turn off autodocs for method aliases
- [x] better name for "uncheck_others" argument to set_checkboxes
- [x] InvalidFormMethod is not showing up in Sphinx
- [x] Document changes in the changelog