### PR TITLE
setup.cfg: activate all-files and fresh-env (-a -E)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,5 @@ flake8-ignore =
 [build_sphinx]
 source-dir = docs/
 build-dir  = docs/_build
-all_files  = 1
+all-files  = 1
+fresh-env  = 1


### PR DESCRIPTION
By default, autodoc caches its results in
docs/_build/doctrees/mechanicalsoup.doctree and doesn't regenerate it
when docstrings are modified.

Force a more brutal approach where everything is rebuilt each time.

Fixes #128.