### PR TITLE
Improve docstrings

### DIFF
--- a/docs/mechanicalsoup.rst
+++ b/docs/mechanicalsoup.rst
@@ -1,8 +1,35 @@
 The mechanicalsoup package: API documentation
 =============================================
 
-.. automodule:: mechanicalsoup
+.. module:: mechanicalsoup
+
+StatefulBrowser
+---------------
+
+.. autoclass:: StatefulBrowser
     :members:
     :undoc-members:
     :show-inheritance:
-    :special-members: __init__, __setitem__
+    :special-members: __setitem__
+
+Browser
+-------
+
+.. autoclass:: Browser
+    :members:
+    :undoc-members:
+
+Form
+----
+
+.. autoclass:: Form
+    :members:
+    :undoc-members:
+    :special-members: __setitem__
+
+Exceptions
+----------
+.. autoexception:: LinkNotFoundError
+    :show-inheritance:
+.. autoexception:: InvalidFormMethod
+    :show-inheritance:

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -77,6 +77,10 @@ class Browser(object):
         """Straightforward wrapper around `requests.Session.request
         <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
 
+        :return: `requests.Response
+            <http://docs.python-requests.org/en/master/api/#requests.Response>`__
+            object with a *soup*-attribute added by :func:`add_soup`.
+
         This is a low-level function that should not be called for
         basic usage (use :func:`get` or :func:`post` instead). Use it if you
         need an HTTP verb that MechanicalSoup doesn't manage (e.g. MKCOL) for
@@ -89,6 +93,10 @@ class Browser(object):
     def get(self, *args, **kwargs):
         """Straightforward wrapper around `requests.Session.get
         <http://docs.python-requests.org/en/master/api/#requests.Session.get>`__.
+
+        :return: `requests.Response
+            <http://docs.python-requests.org/en/master/api/#requests.Response>`__
+            object with a *soup*-attribute added by :func:`add_soup`.
         """
         response = self.session.get(*args, **kwargs)
         if self.__raise_on_404 and response.status_code == 404:
@@ -99,6 +107,10 @@ class Browser(object):
     def post(self, *args, **kwargs):
         """Straightforward wrapper around `requests.Session.post
         <http://docs.python-requests.org/en/master/api/#requests.Session.post>`__.
+
+        :return: `requests.Response
+            <http://docs.python-requests.org/en/master/api/#requests.Response>`__
+            object with a *soup*-attribute added by :func:`add_soup`.
         """
         response = self.session.post(*args, **kwargs)
         Browser.add_soup(response, self.soup_config)
@@ -182,6 +194,10 @@ class Browser(object):
             relative path, then this must be specified.
         :param \*\*kwargs: Arguments forwarded to `requests.Request
             <http://docs.python-requests.org/en/master/api/#requests.Request>`__.
+
+        :return: `requests.Response
+            <http://docs.python-requests.org/en/master/api/#requests.Response>`__
+            object with a *soup*-attribute added by :func:`add_soup`.
         """
         if isinstance(form, Form):
             form = form.form

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -19,6 +19,21 @@ class Browser(object):
 
     def __init__(self, session=None, soup_config=None, requests_adapters=None,
                  raise_on_404=False, user_agent=None):
+        """Builds a Browser.
+
+        :param session: Attach a pre-existing requests Session instead of
+            constructing a new one.
+        :param soup_config: Configuration passed to MechanicalSoup to affect
+            the way HTML is parsed.
+        :param requests_adapters: Configuration passed to requests, to affect
+            the way HTTP requests are performed.
+        :param raise_on_404: If True, raise :class:`LinkNotFoundError`
+            when visiting a page triggers a 404 Not Found error.
+        :param user_agent: Set the user agent header to this value.
+
+        See also: :func:`StatefulBrowser`
+        """
+
         self.__raise_on_404 = raise_on_404
         self.session = session or requests.Session()
 
@@ -32,6 +47,7 @@ class Browser(object):
 
     @staticmethod
     def add_soup(response, soup_config):
+        """Attaches a soup object to a requests response."""
         if "text/html" in response.headers.get("Content-Type", ""):
             response.soup = bs4.BeautifulSoup(
                 response.content, **soup_config)
@@ -39,7 +55,8 @@ class Browser(object):
     def set_cookiejar(self, cookiejar):
         """Replaces the current cookiejar in the requests session. Since the
         session handles cookies automatically without calling this function,
-        only use this when default cookie handling is insufficient."""
+        only use this when default cookie handling is insufficient.
+        """
         self.session.cookies = cookiejar
 
     def get_cookiejar(self):
@@ -47,6 +64,7 @@ class Browser(object):
         return self.session.cookies
 
     def set_user_agent(self, user_agent):
+        """Replaces the current user agent in the requests session headers."""
         # set a default user_agent if not specified
         if user_agent is None:
             requests_ua = requests.utils.default_user_agent()
@@ -56,12 +74,12 @@ class Browser(object):
         self.session.headers['User-agent'] = user_agent
 
     def request(self, *args, **kwargs):
-        """Straightforward wrapper around requests session.request
-        (http://docs.python-requests.org/en/master/api/).
+        """Straightforward wrapper around `requests.Session.request
+        <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
 
         This is a low-level function that should not be called for
-        basic usage (use .get or .post instead). Use it if you need an
-        HTTP verb that mechanicalsoup doesn't manage (e.g. MKCOL) for
+        basic usage (use :func:`get` or :func:`post` instead). Use it if you
+        need an HTTP verb that MechanicalSoup doesn't manage (e.g. MKCOL) for
         example.
         """
         response = self.session.request(*args, **kwargs)
@@ -69,6 +87,9 @@ class Browser(object):
         return response
 
     def get(self, *args, **kwargs):
+        """Straightforward wrapper around `requests.Session.get
+        <http://docs.python-requests.org/en/master/api/#requests.Session.get>`__.
+        """
         response = self.session.get(*args, **kwargs)
         if self.__raise_on_404 and response.status_code == 404:
             raise LinkNotFoundError()
@@ -76,6 +97,9 @@ class Browser(object):
         return response
 
     def post(self, *args, **kwargs):
+        """Straightforward wrapper around `requests.Session.post
+        <http://docs.python-requests.org/en/master/api/#requests.Session.post>`__.
+        """
         response = self.session.post(*args, **kwargs)
         Browser.add_soup(response, self.soup_config)
         return response
@@ -151,6 +175,14 @@ class Browser(object):
         return self.session.prepare_request(request)
 
     def submit(self, form, url=None, **kwargs):
+        """Prepares and sends a form request.
+
+        :param form: The filled-out form.
+        :param url: URL of the page the form is on. If the form action is a
+            relative path, then this must be specified.
+        :param \*\*kwargs: Arguments forwarded to `requests.Request
+            <http://docs.python-requests.org/en/master/api/#requests.Request>`__.
+        """
         if isinstance(form, Form):
             form = form.form
         request = self._prepare_request(form, url, **kwargs)
@@ -159,7 +191,7 @@ class Browser(object):
         return response
 
     def launch_browser(self, soup):
-        """Launch a browser on the page, for debugging purpose."""
+        """Launch a browser on the page, for debugging purposes."""
         with tempfile.NamedTemporaryFile(delete=False) as file:
             file.write(soup.encode())
         webbrowser.open('file://' + file.name)

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -16,23 +16,23 @@ warnings.filterwarnings(
 
 
 class Browser(object):
+    """Builds a Browser.
+
+    :param session: Attach a pre-existing requests Session instead of
+        constructing a new one.
+    :param soup_config: Configuration passed to MechanicalSoup to affect
+        the way HTML is parsed.
+    :param requests_adapters: Configuration passed to requests, to affect
+        the way HTTP requests are performed.
+    :param raise_on_404: If True, raise :class:`LinkNotFoundError`
+        when visiting a page triggers a 404 Not Found error.
+    :param user_agent: Set the user agent header to this value.
+
+    See also: :func:`StatefulBrowser`
+    """
 
     def __init__(self, session=None, soup_config=None, requests_adapters=None,
                  raise_on_404=False, user_agent=None):
-        """Builds a Browser.
-
-        :param session: Attach a pre-existing requests Session instead of
-            constructing a new one.
-        :param soup_config: Configuration passed to MechanicalSoup to affect
-            the way HTML is parsed.
-        :param requests_adapters: Configuration passed to requests, to affect
-            the way HTTP requests are performed.
-        :param raise_on_404: If True, raise :class:`LinkNotFoundError`
-            when visiting a page triggers a 404 Not Found error.
-        :param user_agent: Set the user agent header to this value.
-
-        See also: :func:`StatefulBrowser`
-        """
 
         self.__raise_on_404 = raise_on_404
         self.session = session or requests.Session()

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -16,7 +16,11 @@ class InvalidFormMethod(LinkNotFoundError):
 
 
 class Form(object):
-    """The Form class is responsible for preparing HTML forms for submission.
+    """Build a fillable form.
+
+    :param form: A bs4.element.Tag corresponding to an HTML form element.
+
+    The Form class is responsible for preparing HTML forms for submission.
     It handles the following types of elements:
     input (text, checkbox, radio), select, and textarea.
 
@@ -29,9 +33,6 @@ class Form(object):
     """
 
     def __init__(self, form):
-        """Create a Form from a bs4.element.Tag ``form``. The Tag is expected
-        to correspond to an HTML form element.
-        """
         self.form = form
 
         # Aliases for backwards compatibility

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -29,6 +29,9 @@ class Form(object):
     """
 
     def __init__(self, form):
+        """Create a Form from a bs4.element.Tag ``form``. The Tag is expected
+        to correspond to an HTML form element.
+        """
         self.form = form
 
         # Aliases for backwards compatibility
@@ -232,6 +235,10 @@ class Form(object):
         raise LinkNotFoundError("No valid element named " + name)
 
     def new_control(self, type, name, value, **kwargs):
+        """Add a new input element to the form.
+
+        The arguments set the attributes of the new element.
+        """
         old_input = self.form.find_all('input', {'name': name})
         for old in old_input:
             old.decompose()
@@ -250,21 +257,26 @@ class Form(object):
         return control
 
     def choose_submit(self, el):
-        '''Selects the submit input (or button) element specified by 'el',
-        where 'el' can be either a bs4.element.Tag or just its name attribute.
-        If the element is not found or if multiple elements match, raise a
-        LinkNotFoundError exception.'''
-        # In a normal web browser, when a input[type=submit] is clicked,
-        # all other submits aren't sent. You can use simulate this as
-        # following:
+        """Selects the input (or button) element to use for form submission.
 
-        # page = browser.get(URL)
-        # form_el = page.soup.form
-        # form = Form(form_el)
-        # submit = page.soup.select(SUBMIT_SELECTOR)[0]
-        # form.choose_submit(submit)
-        # url = BASE_DOMAIN + form_el.attrs['action']
-        # return browser.submit(form, url)
+        :param el: The bs4.element.Tag (or just its *name*-attribute) that
+            identifies the submit element to use.
+
+        To simulate a normal web browser, only one submit element must be
+        sent. Therefore, this does not need to be called if there is only
+        one submit element in the form.
+
+        If the element is not found or if multiple elements match, raise a
+        :class:`LinkNotFoundError` exception.
+
+        Example: ::
+
+            browser = mechanicalsoup.StatefulBrowser()
+            browser.open(url)
+            form = browser.select_form()
+            form.choose_submit('form_name_attr')
+            browser.submit_selected()
+        """
 
         found = False
         inps = self.form.select('input[type="submit"], button[type="submit"]')

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -15,8 +15,7 @@ class StatefulBrowser(Browser):
     It is the primary tool in MechanicalSoup for interfacing with websites.
     """
 
-    def __init__(self, session=None, soup_config=None, requests_adapters=None,
-                 *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Build a StatefulBrowser.
 
         :param session: Attach a pre-existing requests Session instead of
@@ -45,8 +44,7 @@ class StatefulBrowser(Browser):
         Once not used anymore, the browser must be closed
         using :func:`~Browser.close`.
         """
-        super(StatefulBrowser, self).__init__(
-            session, soup_config, requests_adapters, *args, **kwargs)
+        super(StatefulBrowser, self).__init__(*args, **kwargs)
         self.__debug = False
         self.__verbose = 0
         self.__current_page = None

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -251,7 +251,7 @@ class StatefulBrowser(Browser):
         Before raising, if debug is activated, list available links in the
         page and launch a browser.
 
-        :return: Forwarded from :func:`open`.
+        :return: Forwarded from :func:`open_relative`.
         """
         if not hasattr(link, 'attrs') or 'href' not in link.attrs:
             try:
@@ -262,7 +262,7 @@ class StatefulBrowser(Browser):
                     self.list_links()
                     self.launch_browser()
                 raise
-        return self.open(self.absolute_url(link['href']))
+        return self.open_relative(link['href'])
 
     def launch_browser(self):
         """Launch a browser on the page, for debugging purposes."""

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -223,7 +223,7 @@ class StatefulBrowser(Browser):
                          if a.text == link_text]
         return all_links
 
-    def find_link(self, url_regex=None, *args, **kwargs):
+    def find_link(self, *args, **kwargs):
         """Find and return a link, as a bs4.element.Tag object.
 
         The search can be refined by specifying any argument that is accepted
@@ -231,7 +231,7 @@ class StatefulBrowser(Browser):
 
         If no link is found, raise :class:`LinkNotFoundError`.
         """
-        links = self.links(url_regex, *args, **kwargs)
+        links = self.links(*args, **kwargs)
         if len(links) == 0:
             raise LinkNotFoundError()
         else:

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -13,37 +13,35 @@ class StatefulBrowser(Browser):
     """An extension of :class:`Browser` that stores the browser's state
     and provides many convenient functions for interacting with HTML elements.
     It is the primary tool in MechanicalSoup for interfacing with websites.
+
+    :param session: Attach a pre-existing requests Session instead of
+        constructing a new one.
+    :param soup_config: Configuration passed to MechanicalSoup to affect
+        the way HTML is parsed.
+    :param requests_adapters: Configuration passed to requests, to affect
+        the way HTTP requests are performed.
+    :param raise_on_404: If True, raise :class:`LinkNotFoundError`
+        when visiting a page triggers a 404 Not Found error.
+    :param user_agent: Set the user agent header to this value.
+
+    All arguments are forwarded to :func:`Browser`.
+
+    Examples ::
+
+        browser = mechanicalsoup.StatefulBrowser(
+            soup_config={'features': 'lxml'},  # Use the lxml HTML parser
+            raise_on_404=True,
+            user_agent='MyBot/0.1: mysite.example.com/bot_info',
+        )
+        browser.open(url)
+        # ...
+        browser.close()
+
+    Once not used anymore, the browser must be closed
+    using :func:`~Browser.close`.
     """
 
     def __init__(self, *args, **kwargs):
-        """Build a StatefulBrowser.
-
-        :param session: Attach a pre-existing requests Session instead of
-            constructing a new one.
-        :param soup_config: Configuration passed to MechanicalSoup to affect
-            the way HTML is parsed.
-        :param requests_adapters: Configuration passed to requests, to affect
-            the way HTTP requests are performed.
-        :param raise_on_404: If True, raise :class:`LinkNotFoundError`
-            when visiting a page triggers a 404 Not Found error.
-        :param user_agent: Set the user agent header to this value.
-
-        All arguments are forwarded to :func:`Browser.__init__`.
-
-        Examples ::
-
-            browser = mechanicalsoup.StatefulBrowser(
-                soup_config={'features': 'lxml'},  # Use the lxml HTML parser
-                raise_on_404=True,
-                user_agent='MyBot/0.1: mysite.example.com/bot_info',
-            )
-            browser.open(url)
-            # ...
-            browser.close()
-
-        Once not used anymore, the browser must be closed
-        using :func:`~Browser.close`.
-        """
         super(StatefulBrowser, self).__init__(*args, **kwargs)
         self.__debug = False
         self.__verbose = 0


### PR DESCRIPTION
In this PR:
* Add missing docstrings
* Improve clarity of existing text
* Add many sphinx function/class links
* Add some sphinx `:param:` or `:return:` docs
* More links to external resources when we use another object's API

Things not in this PR:
* Complete coverage of `:param:` and `:return:` (these can be a bit clunky for simple functions, but we may decide that we want to include them in the end)
* Example code

I think there's still a lot of room for improvement, but it's a good first pass. This also cleans up the internal interface a bit where I noticed areas for improvement while documenting.

- [x] StatefulBrowser
- [x] Browser
- [x] Form