### PR TITLE
form.py: rename argument of choose_submit

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -257,10 +257,10 @@ class Form(object):
         self.form.append(control)
         return control
 
-    def choose_submit(self, el):
+    def choose_submit(self, submit):
         """Selects the input (or button) element to use for form submission.
 
-        :param el: The bs4.element.Tag (or just its *name*-attribute) that
+        :param submit: The bs4.element.Tag (or just its *name*-attribute) that
             identifies the submit element to use.
 
         To simulate a normal web browser, only one submit element must be
@@ -282,10 +282,10 @@ class Form(object):
         found = False
         inps = self.form.select('input[type="submit"], button[type="submit"]')
         for inp in inps:
-            if inp == el or inp['name'] == el:
+            if inp == submit or inp['name'] == submit:
                 if found:
                     raise LinkNotFoundError(
-                        "Multiple submit elements match: {0}".format(el)
+                        "Multiple submit elements match: {0}".format(submit)
                     )
                 found = True
                 continue
@@ -294,7 +294,7 @@ class Form(object):
 
         if not found:
             raise LinkNotFoundError(
-                "Specified submit element not found: {0}".format(el)
+                "Specified submit element not found: {0}".format(submit)
             )
 
     def print_summary(self):


### PR DESCRIPTION
The name `el` was not sufficiently descriptive or clear. Instead,
we name it `submit` because it is the Tag of the submit element
or its name-attribute.

---------------------------
We are deciding whether or not to make this change, because it could in theory break backwards compatibility if someone were to have written `choose_submit(el=foo)`. See previous discussion in PR #131.