### PR TITLE
browser.py: add_soup now always attaches a soup

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -46,8 +46,9 @@ Bug fixes
 * Checking checkboxes with ``browser["name"] = ("val1", "val2")`` now
   unchecks all checkbox except the ones explicitly specified.
 
-* ``StatefulBrowser.submit_selected`` now resets __current_page even
-  when the target of the form is not an HTML page.
+* ``StatefulBrowser.submit_selected`` and ``StatefulBrowser.open`` now
+  reset __current_page to None when the result is not an HTML page.
+  This fixes a bug where __current_page was still the previous page.
 
 * We don't error out anymore when trying to uncheck a box which
   doesn't have a ``checkbox`` attribute.
@@ -59,6 +60,9 @@ Internal Changes
 
 * Tests are now ran against the local version of MechanicalSoup, not
   against the installed version.
+
+* ``Browser.add_soup`` will now always attach a *soup*-attribute.
+  If the response is not text/html, then soup is set to None.
 
 Version 0.8
 ===========

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -49,8 +49,9 @@ class Browser(object):
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
         if "text/html" in response.headers.get("Content-Type", ""):
-            response.soup = bs4.BeautifulSoup(
-                response.content, **soup_config)
+            response.soup = bs4.BeautifulSoup(response.content, **soup_config)
+        else:
+            response.soup = None
 
     def set_cookiejar(self, cookiejar):
         """Replaces the current cookiejar in the requests session. Since the

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -118,8 +118,7 @@ class StatefulBrowser(Browser):
             print(url)
 
         resp = self.get(url, *args, **kwargs)
-        if hasattr(resp, 'soup'):
-            self.__current_page = resp.soup
+        self.__current_page = resp.soup
         self.__current_url = resp.url
         self.__current_form = None
         return resp
@@ -185,10 +184,7 @@ class StatefulBrowser(Browser):
                            url=self.__current_url,
                            *args, **kwargs)
         self.__current_url = resp.url
-        if hasattr(resp, "soup"):
-            self.__current_page = resp.soup
-        else:
-            self.__current_page = None
+        self.__current_page = resp.soup
         self.__current_form = None
         return resp
 


### PR DESCRIPTION
Instead of omitting the soup attribute when the response is not
text/html, set it to None. This has two positive effects:

1. StatefulBrowser can now unconditionally set the current page
   from response.soup. We no longer need to remember to handle the
   case when response.soup is not set.

2. We fix another hidden bug in StatefulBrowser.open, which is the
   same bug @moy recently fixed in StatefulBrowser.submit_selected.
   Specifically, when the page is not text/html, we no longer keep
   the previous page in memory.