### PR TITLE
browser: implement __enter__ and __exit__

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -60,6 +60,15 @@ the destructor (``__del__``) of browser. The solution is to
 call :func:`~mechanicalsoup.Browser.close` before the end of life of
 the object.
 
+Alternatively, you may also use the ``with`` statement which closes
+the browser for you::
+
+  def test_with():
+      with mechanicalsoup.StatefulBrowser() as browser:
+          browser.open(url)
+          # ...
+      # implicit call to browser.close() here.
+
 How do I get debug information/logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -222,3 +222,9 @@ class Browser(object):
 
     def __del__(self):
         self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -295,6 +295,11 @@ def test_form_multiple():
     response = browser.submit_selected()
     browser.close()
 
+def test_with():
+    """Test that __enter__/__exit__ properly create/close the browser."""
+    with mechanicalsoup.StatefulBrowser() as browser:
+        assert browser.session is not None
+    assert browser.session is None
 
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
We implement the same methods as request.session, allowing code like

  def test_with():
      with mechanicalsoup.StatefulBrowser() as browser:
          browser.open(url)
	  # ...
      # implicit call to browser.close() here.