### PR TITLE
form.py: support <select multiple>

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -40,6 +40,9 @@ Main changes:
   ``browser.get_current_form().print_summary()`` to get a summary of the
   fields you need to fill-in (and which ones are already filled-in).
 
+* The ``Form`` class now supports selecting multiple options in
+  a ``<select multiple>`` element.
+
 Bug fixes
 ---------
 


### PR DESCRIPTION
Fixes #124.

Normally, only one option of a select element can be selected.
But in a `<select multiple>`, it is valid HTML to select multiple
options.

We now support this with the following syntax:
```python
  # select option1 and option2
  form.set_select({'name': ('option1', 'option2')})
```