### PR TITLE
More explicit example variable names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ a DuckDuckGo search:
     browser.submit_selected()
 
     # Display the results
-    for l in browser.get_current_page().select('a.result__a'):
-        print(l.text, '->', l.attrs['href'])
+    for link in browser.get_current_page().select('a.result__a'):
+        print(link.text, '->', link.attrs['href'])
 
 More examples are available in `<examples/>`__.
 

--- a/examples/expl_duck_duck_go.py
+++ b/examples/expl_duck_duck_go.py
@@ -13,5 +13,5 @@ browser["q"] = "MechanicalSoup"
 browser.submit_selected()
 
 # Display the results
-for l in browser.get_current_page().select('a.result__a'):
-    print(l.text, '->', l.attrs['href'])
+for link in browser.get_current_page().select('a.result__a'):
+    print(link.text, '->', link.attrs['href'])

--- a/examples/expl_google.py
+++ b/examples/expl_google.py
@@ -11,8 +11,8 @@ browser["q"] = "MechanicalSoup"
 browser.submit_selected(btnName="btnG")
 
 # Display links
-for l in browser.links():
-    target = l.attrs['href']
+for link in browser.links():
+    target = link.attrs['href']
     # Filter-out unrelated links and extract actual URL from Google's
     # click-tracking.
     if (target.startswith('/url?') and not


### PR DESCRIPTION
Since the example scripts are what people will often look at
to learn how MechanicalSoup works, we want them to be as obvious
as possible. For that reason, rename the loop variables:
'l' -> 'link'