### PR TITLE
.travis-ci.yml: basic back-off strategy when httpbin is down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ python:
 install:
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
   - pip install pytest-cov       # needed for the codecov uploader
+before_script:
+  - ./wait-for-httpbin.sh
 script:
   - python setup.py test
 after_success:

--- a/wait-for-httpbin.sh
+++ b/wait-for-httpbin.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# httpbin sometimes times out, but comes back shortly after this
+# happens. Apply a basic backoff scheme to give a chance to the tests
+# to run later instead of failing.
+for i in 1 2 3
+do
+    if curl http://httpbin.org >/dev/null
+    then
+        break
+    fi
+    duration=$(($RANDOM % 100 + 100 * i))
+    echo "Sleeping for $duration seconds"
+    sleep $duration
+done


### PR DESCRIPTION
Hopefully this will reduce the failure rate on Travis-CI.