### PR TITLE
README.rst: move "See also" section to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,14 +108,6 @@ Common problems
 Read the `FAQ
 <https://mechanicalsoup.readthedocs.io/en/latest/faq.html>`__.
 
-See also
---------
-
--  `RoboBrowser <https://github.com/jmcarp/robobrowser>`__: a similar
-   library, also based on Requests and BeautifulSoup.
--  `Hacker News post <https://news.ycombinator.com/item?id=8012103>`__
--  `Reddit
-   discussion <https://www.reddit.com/r/programming/comments/2aa13s/mechanicalsoup_a_python_library_for_automating/>`__
 
 .. |Latest Version| image:: https://img.shields.io/pypi/v/MechanicalSoup.svg
    :target: https://pypi.python.org/pypi/MechanicalSoup/

--- a/docs/external-resources.rst
+++ b/docs/external-resources.rst
@@ -18,6 +18,13 @@ MechanicalSoup on the web
 * `MechanicalSoup on Gitter
   <https://gitter.im/MechanicalSoup/Lobby>`__
 
+* News archive:
+
+  * `opensource.com blog <https://opensource.com/resources/python/web-scraper-crawler>`__
+  * `Hacker News post <https://news.ycombinator.com/item?id=8012103>`__
+  * `Reddit
+    discussion <https://www.reddit.com/r/programming/comments/2aa13s/mechanicalsoup_a_python_library_for_automating/>`__
+
 Projects using MechanicalSoup
 -----------------------------
 


### PR DESCRIPTION
The main README no longer seems like an appropriate place for
these references. We have the FAQ which discusses RoboBrowser
extensively, and I've added a "news archive" bullet in
`docs/external-resources.rst`.