### PR TITLE
Prepare for next release

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ At each release:
 
 Right after the release:
 
-- Update the version number to a ``x.y.dev`` number in
+- Update the version number to a ``x.y.z-dev`` number in
   ``mechanicalsoup/__version__.py``
 - Create the ``(in development)`` section in ``docs/ChangeLog.rst``.
 - ``git commit -m "Prepare for next release" && git push``

--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -2,6 +2,9 @@
 Release Notes
 =============
 
+Version 1.0 (in development)
+============================
+
 Version 0.9
 ===========
 

--- a/mechanicalsoup/__version__.py
+++ b/mechanicalsoup/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'MechanicalSoup'
 __description__ = 'A Python library for automating interaction with websites'
 __url__ = 'http://mechanicalsoup.readthedocs.io/'
-__version__ = '0.9.0'
+__version__ = '1.0.0-dev'
 __license__ = 'MIT'


### PR DESCRIPTION
The next release is expected to be v1.0.0. While in development,
the version will be reported as "1.0.0-dev".

Since I cannot upload to PyPI, I'm making this available to be merged after the upload is finished, as per the release checklist.