### PR TITLE
Test full QSL in setup_mock_browser

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -311,8 +311,8 @@ submit_form_multiple = '''
 
 
 def test_form_multiple():
-    browser, url = setup_mock_browser(expected_post=[('foo', 'tempeh'),
-                                                     ('foo', 'tofu')])
+    browser, url = setup_mock_browser(expected_post=[('foo', 'tofu'),
+                                                     ('foo', 'tempeh')])
     browser.open_fake_page(submit_form_multiple, url=url)
     browser.select_form('#choose-submit-form')
     response = browser.submit_selected()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,7 @@ def setup_mock_browser(expected_post=None, text=choose_submit_form):
         def text_callback(request, context):
             # Python 2's parse_qsl doesn't like None argument
             query = parse_qsl(request.text) if request.text else ()
-            assert(set(query) == set(expected_post))
+            assert list(query) == list(expected_post)
             return 'Success!'
         mock.register_uri('POST', url + '/post', text=text_callback)
 


### PR DESCRIPTION
Related to #158.

Compare the expected and posted QSL as lists rather than sets
to avoid clobbering multiple elements with the same name.

For example:
```python
parse_qsl('x=1&x=1') != parse_qsl('x=1')
```
even though
```python
set(parse_qsl('x=1&x=1')) == set(parse_qsl('x=1'))
```
Since valid HTML can produce both query strings, we should be
able to distinguish between them in our tests.