### PR TITLE
Fix QSL for repeated form elements

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,16 @@ Release Notes
 Version 1.0 (in development)
 ============================
 
+Bug fixes:
+----------
+
+* Improve consistency of query string construction between MechanicalSoup
+  and web browsers in edge cases where form elements have duplicate names.
+  This only affects duplicate-named ``input`` elements that don't have a
+  *type* and ``textarea`` elements; all values will show up in the query
+  string instead of just the last.
+  See `#158 <https://github.com/MechanicalSoup/MechanicalSoup/issues/158>`__.
+
 Version 0.9
 ===========
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -143,9 +143,9 @@ class Browser(object):
                 # web browsers use empty string for inputs with missing values
                 value = input.get("value", "")
 
-            if input.get("type") == "checkbox":
-                data.setdefault(name, []).append(value)
-
+            if input.get("type") == "radio":
+                # Uses the last checked radio (only one should be checked)
+                data[name] = value
             elif input.get("type") == "file":
                 # read http://www.cs.tut.fi/~jkorpela/forms/file.html
                 # in web browsers, file upload only happens if the form"s (or
@@ -156,15 +156,14 @@ class Browser(object):
                 if isinstance(value, string_types):
                     value = open(value, "rb")
                 files[name] = value
-
             else:
-                data[name] = value
+                data.setdefault(name, []).append(value)
 
         for textarea in form.select("textarea"):
             name = textarea.get("name")
             if not name:
                 continue
-            data[name] = textarea.text
+            data.setdefault(name, []).append(textarea.text)
 
         for select in form.select("select"):
             name = select.get("name")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -70,9 +70,9 @@ def test_build_request():
     browser = mechanicalsoup.Browser()
     request = browser._build_request(form)
 
-    assert request.data["customer"] == "Philip J. Fry"
-    assert request.data["telephone"] == "555"
-    assert request.data["comments"] == "freezer"
+    assert request.data["customer"] == ["Philip J. Fry"]
+    assert request.data["telephone"] == ["555"]
+    assert request.data["comments"] == ["freezer"]
     assert request.data["size"] == "medium"
     assert request.data["topping"] == ["cheese", "onion"]
     assert request.data["shape"] == "square"

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -361,5 +361,23 @@ def test_form_print_summary(capsys):
     assert err == ""
 
 
+def test_issue158():
+    issue158_form = '''
+<form method="post" action="mock://form.com/post">
+  <input name="box" type="hidden" value="0"/>
+  <input checked="checked" name="box" type="checkbox" value="1"/>
+  <input type="submit" value="Submit" />
+</form>
+'''
+    expected_post = (('box', '0'), ('box', '1'))
+    browser, url = setup_mock_browser(expected_post=expected_post,
+                                      text=issue158_form)
+    browser.open(url)
+    browser.select_form()
+    res = browser.submit_selected()
+    assert(res.status_code == 200 and res.text == 'Success!')
+    browser.close()
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
Closes #158.

Improve consistency of query string construction between
MechanicalSoup and web browsers in edge cases where form elements
have duplicate *name*-attributes.

This change affects duplicate-named `input` elements that don't
have a *type*-attribute and `textarea` elements; all values will
show up in the query string instead of just the last.

For example, if a form with the following is submitted:
```
<input name="key" value="val1" />
<input name="key" value="val2" />
```
Then the resulting query string will now be
```
key=val1&key=val2
```
instead of
```
key=val2
```
This also fixes an even more unlikely scenario where an exception
is thrown when a checkbox and a type-less input have the same name.