### PR TITLE
.travis.yml: enable the pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 sudo: false
 language: python
+cache: pip
 python:
   - 2.7
   - 3.4


### PR DESCRIPTION
This caches `$HOME/.cache/pip` in Travis builds.

Our Travis build time is often dominated by dependency installation,
so caching pip can speed up builds significantly.

The cache can be managed at:
https://travis-ci.org/MechanicalSoup/MechanicalSoup/caches