### PR TITLE
.travis.yml: don't use flake8 in pypy environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ python:
 install:
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
   - pip install pytest-cov       # needed for the codecov uploader
+  - pip install -r requirements.txt -r tests/requirements.txt
 before_script:
   - ./tests/wait-for-httpbin.sh
 script:
-  - python setup.py test
+  # Do not perform flake8 checks in pypy environments (see issue #146)
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then pytest -o 'flake8-ignore=*.py ALL'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pytest; fi
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
 


### PR DESCRIPTION
Closes #146.

Until we understand why flake8 is so slow in pypy environments
(to the point where it causes Travis to stall), do not run flake8
tests in these environments.

We do this by overriding the option specified in `setup.cfg` about
which files flake8 should ignore, telling it to instead ignore all
files. This is slightly hacky because a) we still want flake8 to
always be run by users and by all other environments and b) there
is no '--no-flake8' option.

We are still running flake8 tests in all standard python envs,
so there is no real loss of testing coverage.