### PR TITLE
browser.py: refactor Browser.submit method

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,19 @@ Release Notes
 Version 1.0 (in development)
 ============================
 
+Main changes:
+-------------
+* ``Browser.submit`` and ``StatefulBrowser.submit_selected`` accept a larger
+  number of keyword arguments. Arguments are forwarded to
+  `requests.Session.request <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
+  [`#166 <https://github.com/MechanicalSoup/MechanicalSoup/pull/166>`__]
+
+Internal changes:
+-----------------
+* Private methods ``Browser._build_request`` and ``Browser._prepare_request``
+  have been replaced by a single method ``Browser._request``.
+  [`#166 <https://github.com/MechanicalSoup/MechanicalSoup/pull/166>`__]
+
 Version 0.9
 ===========
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -121,7 +121,7 @@ class Browser(object):
         Browser.add_soup(response, self.soup_config)
         return response
 
-    def _build_request(self, form, url=None, **kwargs):
+    def _request(self, form, url=None, **kwargs):
         method = str(form.get("method", "get"))
         action = form.get("action")
         url = urllib.parse.urljoin(url, action)
@@ -185,11 +185,7 @@ class Browser(object):
         else:
             kwargs["data"] = data
 
-        return requests.Request(method, url, files=files, **kwargs)
-
-    def _prepare_request(self, form, url=None, **kwargs):
-        request = self._build_request(form, url, **kwargs)
-        return self.session.prepare_request(request)
+        return self.session.request(method, url, files=files, **kwargs)
 
     def submit(self, form, url=None, **kwargs):
         """Prepares and sends a form request.
@@ -197,8 +193,8 @@ class Browser(object):
         :param form: The filled-out form.
         :param url: URL of the page the form is on. If the form action is a
             relative path, then this must be specified.
-        :param \*\*kwargs: Arguments forwarded to `requests.Request
-            <http://docs.python-requests.org/en/master/api/#requests.Request>`__.
+        :param \*\*kwargs: Arguments forwarded to `requests.Session.request
+            <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
 
         :return: `requests.Response
             <http://docs.python-requests.org/en/master/api/#requests.Response>`__
@@ -206,8 +202,7 @@ class Browser(object):
         """
         if isinstance(form, Form):
             form = form.form
-        request = self._prepare_request(form, url, **kwargs)
-        response = self.session.send(request)
+        response = self._request(form, url, **kwargs)
         Browser.add_soup(response, self.soup_config)
         return response
 


### PR DESCRIPTION
Closes #165.

Since both `Browser._prepare_request` and `Browser._build_request` are
internal methods, we can replace them with a single `Browser._request`.

This new method is the same as `_build_request`, except that it calls
`self.Session.request` to prepare and send the request instead of doing
it in two separate steps.

Since `requests.Session.request` both prepares and sends the request,
it has an API that includes keywords for both actions. The keywords
are a superset of `requests.Request` (except for `hooks`, but since
MechanicalSoup did not expose the resulting Request object, I believe
the hooks could not be used).

As a result, the `kwargs` that can be passed to `Browser.submit` has
expanded to include keywords related to sending the request.