### PR TITLE
stateful_browser.py: add soup argument to launch_browser

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -207,7 +207,10 @@ class Browser(object):
         return response
 
     def launch_browser(self, soup):
-        """Launch a browser on the page, for debugging purposes."""
+        """Launch a browser to display a page, for debugging purposes.
+
+        :param: soup: Page contents to display, supplied as a bs4 soup object.
+        """
         with tempfile.NamedTemporaryFile(delete=False) as file:
             file.write(soup.encode())
         webbrowser.open('file://' + file.name)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -265,6 +265,12 @@ class StatefulBrowser(Browser):
                 raise
         return self.open_relative(link['href'])
 
-    def launch_browser(self):
-        """Launch a browser on the page, for debugging purposes."""
-        super(StatefulBrowser, self).launch_browser(self.get_current_page())
+    def launch_browser(self, soup=None):
+        """Launch a browser to display a page, for debugging purposes.
+
+        :param: soup: Page contents to display, supplied as a bs4 soup object.
+            Defaults to the current page of the ``StatefulBrowser`` instance.
+        """
+        if soup is None:
+            soup = self.get_current_page()
+        super(StatefulBrowser, self).launch_browser(soup)


### PR DESCRIPTION
* Defaults to `self.get_current_page()` so that the default
  behavior remains unchanged.

* Improve documentation of both `launch_browser` methods.