### PR TITLE
Fixed a ReferenceError when using Python 3.4.3

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -69,7 +69,10 @@ the browser for you::
           # ...
       # implicit call to browser.close() here.
 	  
-This problem has been fixed in the next release, and this will no longer be required.
+This problem is fixed in MechanicalSoup 1.0, so this is only required
+for compatibility with older versions. Code using new versions can let
+the ``browser`` variable go out of scope and let the garbage collector
+close it properly.
 
 How do I get debug information/logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -68,6 +68,8 @@ the browser for you::
           browser.open(url)
           # ...
       # implicit call to browser.close() here.
+	  
+This problem has been fixed in the next release, and this will no longer be required.
 
 How do I get debug information/logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -38,7 +38,12 @@ class Browser(object):
         self.__raise_on_404 = raise_on_404
         self.session = session or requests.Session()
 
-        self._finalize = weakref.finalize(self.session, self.close)
+        if hasattr(weakref, 'finalize'):
+            self._finalize = weakref.finalize(self.session, self.close)
+        else:
+            # Python < 3 does not have weakref.finalize, but these
+            # versions accept calling session.close() within __del__
+            self._finalize = self.close
 
         self.set_user_agent(user_agent)
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -7,6 +7,7 @@ import webbrowser
 import tempfile
 from .utils import LinkNotFoundError
 from .__version__ import __version__, __title__
+import weakref
 
 
 class Browser(object):
@@ -36,6 +37,8 @@ class Browser(object):
 
         self.__raise_on_404 = raise_on_404
         self.session = session or requests.Session()
+
+        self._finalize = weakref.finalize(self.session, self.close)
 
         self.set_user_agent(user_agent)
 
@@ -223,7 +226,7 @@ class Browser(object):
             self.session = None
 
     def __del__(self):
-        self.close()
+        self._finalize()
 
     def __enter__(self):
         return self

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -42,7 +42,7 @@ class StatefulBrowser(Browser):
         # ...
         browser.close()
 
-    Once not used anymore, the browser must be closed
+    Once not used anymore, the browser can be closed
     using :func:`~Browser.close`.
     """
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -35,7 +35,6 @@ def test_submit_online():
 
     assert json["headers"]["User-Agent"].startswith('python-requests/')
     assert 'MechanicalSoup' in json["headers"]["User-Agent"]
-    browser.close()
 
 
 form_html = """
@@ -80,7 +79,6 @@ def test__request():
 
     assert "application/x-www-form-urlencoded" in response.request.headers[
         "Content-Type"]
-    browser.close()
 
 
 def test__request_file():
@@ -104,14 +102,12 @@ def test__request_file():
             assert (value is None) or ("pic" not in value)
 
     assert "multipart/form-data" in response.request.headers["Content-Type"]
-    browser.close()
 
 
 def test_no_404():
     browser = mechanicalsoup.Browser()
     resp = browser.get("http://httpbin.org/nosuchpage")
     assert resp.status_code == 404
-    browser.close()
 
 
 def test_404():
@@ -120,7 +116,6 @@ def test_404():
         resp = browser.get("http://httpbin.org/nosuchpage")
     resp = browser.get("http://httpbin.org/")
     assert resp.status_code == 200
-    browser.close()
 
 
 def test_set_cookiejar():
@@ -134,7 +129,6 @@ def test_set_cookiejar():
     browser.set_cookiejar(jar)
     resp = browser.get("http://httpbin.org/cookies")
     assert resp.json() == {'cookies': {'field': 'value'}}
-    browser.close()
 
 
 def test_get_cookiejar():
@@ -146,7 +140,6 @@ def test_get_cookiejar():
     jar = browser.get_cookiejar()
     assert jar.get('k1') == 'v1'
     assert jar.get('k2') == 'v2'
-    browser.close()
 
 
 def test_post():
@@ -154,7 +147,6 @@ def test_post():
     data = {'color': 'blue', 'colorblind': 'True'}
     resp = browser.post("http://httpbin.org/post", data)
     assert(resp.status_code == 200 and resp.json()['form'] == data)
-    browser.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -34,7 +34,6 @@ def test_submit_online():
     assert data["size"] == "medium"
     assert data["topping"] == ["cheese", "onion"]
     assert data["comments"] == "freezer"
-    browser.close()
 
 
 def test_submit_set():
@@ -61,7 +60,6 @@ def test_submit_set():
     assert data["size"] == "medium"
     assert data["topping"] == ["cheese", "onion"]
     assert data["comments"] == "freezer"
-    browser.close()
 
 
 @pytest.mark.parametrize("expected_post", [
@@ -93,7 +91,6 @@ def test_choose_submit(expected_post):
     form.choose_submit(expected_post[1][0])
     res = browser.submit_selected()
     assert(res.status_code == 200 and res.text == 'Success!')
-    browser.close()
 
 
 choose_submit_fail_form = '''
@@ -118,7 +115,6 @@ def test_choose_submit_fail(select_name):
             form.choose_submit(select_name['name'])
     else:
         form.choose_submit(select_name['name'])
-    browser.close()
 
 
 choose_submit_multiple_match_form = '''
@@ -137,7 +133,6 @@ def test_choose_submit_multiple_match():
     form = browser.select_form('#choose-submit-form')
     with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
         form.choose_submit('test_submit')
-    browser.close()
 
 
 submit_form_noaction = '''
@@ -160,7 +155,6 @@ def test_form_noaction():
     form['text1'] = 'newText1'
     res = browser.submit_selected()
     assert(res.status_code == 200 and browser.get_url() == url)
-    browser.close()
 
 
 submit_form_action = '''
@@ -185,7 +179,6 @@ def test_form_action():
     form['text1'] = 'newText1'
     res = browser.submit_selected()
     assert(res.status_code == 200 and browser.get_url() == url)
-    browser.close()
 
 
 set_select_form = '''
@@ -218,7 +211,6 @@ def test_set_select(option):
         browser[option['result'][0][0]] = option['result'][0][1]
     res = browser.submit_selected()
     assert(res.status_code == 200 and res.text == 'Success!')
-    browser.close()
 
 
 set_select_multiple_form = '''
@@ -253,7 +245,6 @@ def test_set_select_multiple(options):
     form.set_select({'instrument': options})
     res = browser.submit_selected()
     assert(res.status_code == 200 and res.text == 'Success!')
-    browser.close()
 
 
 def test_form_not_found():
@@ -274,7 +265,6 @@ def test_form_not_found():
         form.set_radio({'size': 'tiny'})
     with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
         form.set_select({'entree': ('no_multiple', 'no_multiple')})
-    browser.close()
 
 
 page_with_radio = '''
@@ -298,7 +288,6 @@ def test_form_check_uncheck():
     # Test explicit unchecking (skipping the call to Form.uncheck_all)
     form.set_checkbox({"foo": False}, uncheck_other_boxes=False)
     assert "checked" not in form.form.find("input", {"name": "foo"}).attrs
-    browser.close()
 
 
 page_with_various_fields = '''

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -15,7 +15,6 @@ def test_request_forward():
     r = browser.request('POST', url + '/post', data={'var1': 'val1',
                                                      'var2': 'val2'})
     assert r.text == 'Success!'
-    browser.close()
 
 
 def test_submit_online():
@@ -52,14 +51,12 @@ def test_submit_online():
     expected_headers = ('Content-Length', 'Host', 'Content-Type', 'Connection',
                         'Accept', 'User-Agent', 'Accept-Encoding')
     assert set(expected_headers).issubset(json["headers"].keys())
-    browser.close()
 
 
 def test_no_404():
     browser = mechanicalsoup.StatefulBrowser()
     resp = browser.open("http://httpbin.org/nosuchpage")
     assert resp.status_code == 404
-    browser.close()
 
 
 def test_404():
@@ -68,14 +65,12 @@ def test_404():
         resp = browser.open("http://httpbin.org/nosuchpage")
     resp = browser.open("http://httpbin.org/")
     assert resp.status_code == 200
-    browser.close()
 
 
 def test_user_agent():
     browser = mechanicalsoup.StatefulBrowser(user_agent='007')
     resp = browser.open("http://httpbin.org/user-agent")
     assert resp.json() == {'user-agent': '007'}
-    browser.close()
 
 
 def test_open_relative():
@@ -92,7 +87,6 @@ def test_open_relative():
     resp = browser.open_relative("/basic-auth/me/123", auth=('me', '123'))
     assert browser.get_url() == "http://httpbin.org/basic-auth/me/123"
     assert resp.json() == {"authenticated": True, "user": "me"}
-    browser.close()
 
 
 def test_links():
@@ -120,7 +114,6 @@ def test_links():
     two_links = browser.links(id=re.compile('_link'))
     assert len(two_links) == 2
     assert two_links == BeautifulSoup(html, "lxml").find_all('a')
-    browser.close()
 
 
 @pytest.mark.parametrize("expected_post", [
@@ -146,7 +139,6 @@ def test_submit_btnName(expected_post):
     browser['comment'] = expected_post[0][1]
     res = browser.submit_selected(btnName=expected_post[1][0])
     assert(res.status_code == 200 and res.text == 'Success!')
-    browser.close()
 
 
 def test_get_set_debug():
@@ -155,7 +147,6 @@ def test_get_set_debug():
     assert(not browser.get_debug())
     browser.set_debug(True)
     assert(browser.get_debug())
-    browser.close()
 
 
 def test_list_links(capsys):
@@ -170,7 +161,6 @@ def test_list_links(capsys):
     out, err = capsys.readouterr()
     expected = 'Links in the current page:{0}'.format(links)
     assert out == expected
-    browser.close()
 
 
 def test_launch_browser(mocker):
@@ -187,7 +177,6 @@ def test_launch_browser(mocker):
         browser.select_form('nosuchlink')
     # mock.assert_called_once() not available on some versions :-(
     assert webbrowser.open.call_count == 1
-    browser.close()
 
 
 def test_find_link():
@@ -195,7 +184,6 @@ def test_find_link():
     browser.open_fake_page('<html></html>')
     with pytest.raises(mechanicalsoup.LinkNotFoundError):
         browser.find_link('nosuchlink')
-    browser.close()
 
 
 def test_verbose(capsys):
@@ -218,7 +206,6 @@ def test_verbose(capsys):
     assert out == "mock://form.com\n"
     assert err == ""
     assert browser.get_verbose() == 2
-    browser.close()
 
 
 def test_new_control():
@@ -245,7 +232,6 @@ def test_new_control():
     assert data["size"] == "Sooo big !"
     assert data["comments"] == "This is an override comment"
     assert data["foo"] == "valval"
-    browser.close()
 
 
 submit_form_noaction = '''
@@ -267,7 +253,6 @@ def test_form_noaction():
     browser.select_form('#choose-submit-form')
     with pytest.raises(ValueError, message="no URL to submit to"):
         browser.submit_selected()
-    browser.close()
 
 
 submit_form_noname = '''
@@ -292,7 +277,6 @@ def test_form_noname():
     browser.select_form('#choose-submit-form')
     response = browser.submit_selected()
     assert(response.status_code == 200 and response.text == 'Success!')
-    browser.close()
 
 
 submit_form_multiple = '''
@@ -317,7 +301,6 @@ def test_form_multiple():
     browser.select_form('#choose-submit-form')
     response = browser.submit_selected()
     assert(response.status_code == 200 and response.text == 'Success!')
-    browser.close()
 
 
 def test_upload_file():
@@ -344,7 +327,6 @@ def test_upload_file():
     files = response.json()["files"]
     assert files["first"] == "first file content"
     assert files["second"] == "second file content"
-    browser.close()
 
 
 def test_with():


### PR DESCRIPTION
This is a fix for ReferenceError: weakly-referenced object no longer exists when mechanicalsoup is used on Python 3.4.3. self.session may have already been garbage collected by the time browser.py gets deleted, so calling self.session.close() will result in this error.

It's resolved by using weakref.finalize instead