### PR TITLE
Add pytest fixture to prepare for pytest-httpbin

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+# This file is automatically discovered by pytest to define
+# shared fixtures only once.
+
+
+@pytest.fixture
+def httpbin():
+    from utils import HttpbinRemote
+    return HttpbinRemote()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -7,10 +7,10 @@ from requests.cookies import RequestsCookieJar
 import pytest
 
 
-def test_submit_online():
+def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.Browser()
-    page = browser.get("http://httpbin.org/forms/post")
+    page = browser.get(httpbin + "/forms/post")
     form = page.soup.form
 
     form.find("input", {"name": "custname"})["value"] = "Philip J. Fry"
@@ -104,21 +104,21 @@ def test__request_file():
     assert "multipart/form-data" in response.request.headers["Content-Type"]
 
 
-def test_no_404():
+def test_no_404(httpbin):
     browser = mechanicalsoup.Browser()
-    resp = browser.get("http://httpbin.org/nosuchpage")
+    resp = browser.get(httpbin + "/nosuchpage")
     assert resp.status_code == 404
 
 
-def test_404():
+def test_404(httpbin):
     browser = mechanicalsoup.Browser(raise_on_404=True)
     with pytest.raises(mechanicalsoup.LinkNotFoundError):
-        resp = browser.get("http://httpbin.org/nosuchpage")
-    resp = browser.get("http://httpbin.org/")
+        resp = browser.get(httpbin + "/nosuchpage")
+    resp = browser.get(httpbin.url)
     assert resp.status_code == 200
 
 
-def test_set_cookiejar():
+def test_set_cookiejar(httpbin):
     """Set cookies locally and test that they are received remotely."""
     # construct a phony cookiejar and attach it to the session
     jar = RequestsCookieJar()
@@ -127,14 +127,14 @@ def test_set_cookiejar():
 
     browser = mechanicalsoup.Browser()
     browser.set_cookiejar(jar)
-    resp = browser.get("http://httpbin.org/cookies")
+    resp = browser.get(httpbin + "/cookies")
     assert resp.json() == {'cookies': {'field': 'value'}}
 
 
-def test_get_cookiejar():
+def test_get_cookiejar(httpbin):
     """Test that cookies set by the remote host update our session."""
     browser = mechanicalsoup.Browser()
-    resp = browser.get("http://httpbin.org/cookies/set?k1=v1&k2=v2")
+    resp = browser.get(httpbin + "/cookies/set?k1=v1&k2=v2")
     assert resp.json() == {'cookies': {'k1': 'v1', 'k2': 'v2'}}
 
     jar = browser.get_cookiejar()
@@ -142,10 +142,10 @@ def test_get_cookiejar():
     assert jar.get('k2') == 'v2'
 
 
-def test_post():
+def test_post(httpbin):
     browser = mechanicalsoup.Browser()
     data = {'color': 'blue', 'colorblind': 'True'}
-    resp = browser.post("http://httpbin.org/post", data)
+    resp = browser.post(httpbin + "/post", data)
     assert(resp.status_code == 200 and resp.json()['form'] == data)
 
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -5,10 +5,10 @@ import sys
 import pytest
 
 
-def test_submit_online():
+def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.Browser()
-    page = browser.get("http://httpbin.org/forms/post")
+    page = browser.get(httpbin + "/forms/post")
     form = mechanicalsoup.Form(page.soup.form)
 
     input_data = {"custname": "Philip J. Fry"}
@@ -36,10 +36,10 @@ def test_submit_online():
     assert data["comments"] == "freezer"
 
 
-def test_submit_set():
+def test_submit_set(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.Browser()
-    page = browser.get("http://httpbin.org/forms/post")
+    page = browser.get(httpbin + "/forms/post")
     form = mechanicalsoup.Form(page.soup.form)
 
     form["custname"] = "Philip J. Fry"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,3 +50,13 @@ def setup_mock_browser(expected_post=None, text=choose_submit_form):
 
     browser = mechanicalsoup.StatefulBrowser(requests_adapters={'mock': mock})
     return browser, url
+
+
+class HttpbinRemote:
+    """Drop-in replacement for pytest-httpbin's httpbin fixture
+    that uses the remote httpbin server instead of a local one."""
+    def __init__(self):
+        self.url = "http://httpbin.org"
+
+    def __add__(self, x):
+        return self.url + x


### PR DESCRIPTION
We add a testing utils class `HttpbinWrapper`, which is simply
a drop-in replacement for the `httpbin` fixture that pytest-httpbin
provides.

This will allow us to write tests in the style of pytest-httpbin
until we can merge PR #164 into master.