### PR TITLE
browser.py: add "no cover" pragma for versioned code

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -40,7 +40,7 @@ class Browser(object):
 
         if hasattr(weakref, 'finalize'):
             self._finalize = weakref.finalize(self.session, self.close)
-        else:
+        else:   # pragma: no cover
             # Python < 3 does not have weakref.finalize, but these
             # versions accept calling session.close() within __del__
             self._finalize = self.close


### PR DESCRIPTION
Use coverage's "no cover" pragma on the else branch of browser.py
that is only ever covered in Python 2 versions.

Even though codecov.io synthesizes reports from all Travis builds
(which includes python 2.7), and therefore sees coverage of this
line, it might be confusing to any developers who are running
individual tests and are expecting 100% coverage.

It's not clear what is best in this situation, but I think that
favoring ease of development in the latest Python version is
preferable to tracking whether or not this line is covered.