### PR TITLE
form.py: harden choose_submit against invalid html

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -307,7 +307,8 @@ class Form(object):
         found = False
         inps = self.form.select('input[type="submit"], button[type="submit"]')
         for inp in inps:
-            if inp == submit or inp['name'] == submit:
+            if inp == submit or (inp.has_attr('name') and
+                                 inp['name'] == submit):
                 if found:
                     raise LinkNotFoundError(
                         "Multiple submit elements match: {0}".format(submit)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -350,5 +350,21 @@ def test_form_print_summary(capsys):
     assert err == ""
 
 
+def test_issue180():
+    """Test that a KeyError is not raised when Form.choose_submit is called
+    on a form where a submit element is missing its name-attribute."""
+    browser = mechanicalsoup.StatefulBrowser()
+    html = '''
+<form>
+  <input type="submit" value="Invalid" />
+  <input type="submit" name="valid" value="Valid" />
+</form>
+'''
+    browser.open_fake_page(html)
+    form = browser.select_form()
+    with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+        form.choose_submit('not_found')
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
Closes #180.

If a submit element exists without a name-attribute, then previously
`Form.choose_submit` would raise a KeyError when it loops over the
elements.

Instead, we should simply ignore any nameless submit element,
regardless of whether it is there because the html is malformed or
because that particular element is used for javascript, for example.