### PR TITLE
stateful_browser.py: add download_link method

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -12,6 +12,10 @@ Main changes:
   `requests.Session.request <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
   [`#166 <https://github.com/MechanicalSoup/MechanicalSoup/pull/166>`__]
 
+* Added method ``StatefulBrowser.download_link``, which will download the
+  contents of a link to a file without changing the state of the browser.
+  [`#170 <https://github.com/MechanicalSoup/MechanicalSoup/issues/170`__]
+
 Internal changes:
 -----------------
 * Private methods ``Browser._build_request`` and ``Browser._prepare_request``

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -35,7 +35,7 @@ class Browser(object):
                  requests_adapters=None,
                  raise_on_404=False, user_agent=None):
 
-        self.__raise_on_404 = raise_on_404
+        self.raise_on_404 = raise_on_404
         self.session = session or requests.Session()
 
         if hasattr(weakref, 'finalize'):
@@ -112,7 +112,7 @@ class Browser(object):
             object with a *soup*-attribute added by :func:`add_soup`.
         """
         response = self.session.get(*args, **kwargs)
-        if self.__raise_on_404 and response.status_code == 404:
+        if self.raise_on_404 and response.status_code == 404:
             raise LinkNotFoundError()
         Browser.add_soup(response, self.soup_config)
         return response

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -278,16 +278,14 @@ class StatefulBrowser(Browser):
             These specify a link to the page whose contents you want to
             download.
         """
-        # Store the current browser state
-        previous_state = self.__state
-        resp = self.follow_link(*args, **kwargs)
-
-        # Restore the previous browser state
-        self.__state = previous_state
+        url = self.follow_link(return_url_only=True, *args, **kwargs)
+        response = self.session.get(url)
+        if self.raise_on_404 and response.status_code == 404:
+            raise LinkNotFoundError()
 
         # Save the response content to file
         with open(filename, 'wb') as f:
-            f.write(resp.content)
+            f.write(response.content)
 
     def launch_browser(self, soup=None):
         """Launch a browser to display a page, for debugging purposes.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -264,6 +264,27 @@ class StatefulBrowser(Browser):
                 raise
         return self.open_relative(link['href'])
 
+    def download_link(self, filename, *args, **kwargs):
+        """Downloads the contents of a link to a file. The browser state
+        will not change when calling this function.
+
+        :param filename: Filesystem path where the page contents will be
+            downloaded.
+        :param \*args, \*\*kwargs: Arguments forwarded to :func:`follow_link`.
+            These specify a link to the page whose contents you want to
+            download.
+        """
+        # Store the current browser state
+        previous_state = self.__state
+        resp = self.follow_link(*args, **kwargs)
+
+        # Restore the previous browser state
+        self.__state = previous_state
+
+        # Save the response content to file
+        with open(filename, 'wb') as f:
+            f.write(resp.content)
+
     def launch_browser(self, soup=None):
         """Launch a browser to display a page, for debugging purposes.
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -237,7 +237,7 @@ class StatefulBrowser(Browser):
         else:
             return links[0]
 
-    def follow_link(self, link=None, *args, **kwargs):
+    def follow_link(self, link=None, return_url_only=False, *args, **kwargs):
         """Follow a link.
 
         If ``link`` is a bs4.element.Tag (i.e. from a previous call to
@@ -262,7 +262,11 @@ class StatefulBrowser(Browser):
                     self.list_links()
                     self.launch_browser()
                 raise
-        return self.open_relative(link['href'])
+        url = link['href']
+        if return_url_only:
+            return self.absolute_url(url)
+        else:
+            return self.open_relative(url)
 
     def download_link(self, filename, *args, **kwargs):
         """Downloads the contents of a link to a file. The browser state

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import setpath  # noqa:F401, must come before 'import mechanicalsoup'
 import mechanicalsoup
@@ -349,6 +350,23 @@ def test_select_form_nr():
         assert form.form['id'] == "c"
         with pytest.raises(mechanicalsoup.LinkNotFoundError):
             browser.select_form(nr=3)
+
+
+def test_download_link(httpbin):
+    """Test downloading the contents of a link to file."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open(httpbin.url)
+    tmpfile = tempfile.NamedTemporaryFile()
+    current_url = browser.get_url()
+    current_page = browser.get_current_page()
+    browser.download_link(tmpfile.name, link='image/png')
+
+    # Check that the browser state has not changed
+    assert browser.get_url() == current_url
+    assert browser.get_current_page() == current_page
+
+    # Check that the file was downloaded
+    assert os.path.isfile(tmpfile.name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #170.

This new method will download the contents of a link to a specified
file without changing the state of the browser (unlike `follow_link`
and similar methods).

--------------

I was not completely certain about the method name, implementation, and how to best test it, so if there are any suggestions, I'm open to further discussion. This is fully functional as far as I'm aware, and ready to be merged, but please consider it a first design draft.