### PR TITLE
Add more succinct state access options

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -12,6 +12,16 @@ Main changes:
   ``StatefulBrowser.download_link`` now sets the ``Referer:`` HTTP
   header to the page from which the link is followed.
 
+* ``StatefulBrowser`` methods ``get_current_page`` and ``get_current_form``
+  have been deprecated in favor of ``get_page`` and ``get_selected_form``
+  respectively. However, you can now access the browser state more conveniently
+  with attributes ``page`` (calls ``get_current_page()``), ``form`` (calls
+  ``get_selected_form()``), and ``url`` (calls ``get_url()``).
+  [`#175 <https://github.com/MechanicalSoup/MechanicalSoup/issues/175`__]
+
+* ``StatefulBrowser.get_selected_form`` will now raise an ``AttributeError``
+  istead of returning ``None`` if no form has been selected yet.
+
 * ``Browser.submit`` and ``StatefulBrowser.submit_selected`` accept a larger
   number of keyword arguments. Arguments are forwarded to
   `requests.Session.request <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -94,15 +94,21 @@ class StatefulBrowser(Browser):
         """Get the current page as a soup object."""
         return self.__state.page
 
+    page = property(get_page)
+
     def get_url(self):
         """Get the URL of the currently visited page."""
         return self.__state.url
+
+    url = property(get_url)
 
     def get_selected_form(self):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
         return self.__state.form
+
+    form = property(get_selected_form)
 
     def __setitem__(self, name, value):
         """Call item assignment on the currently selected form.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -106,6 +106,8 @@ class StatefulBrowser(Browser):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
+        if self.__state.form is None:
+            raise AttributeError("No form has been selected yet on this page.")
         return self.__state.form
 
     form = property(get_selected_form)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -59,6 +59,11 @@ class StatefulBrowser(Browser):
         self.__verbose = 0
         self.__state = _BrowserState()
 
+        # Aliases for backwards compatibility
+        # (Included specifically in __init__ to suppress them in Sphinx docs)
+        self.get_current_page = self.get_page
+        self.get_current_form = self.get_selected_form
+
     def set_debug(self, debug):
         """Set the debug mode (off by default).
 
@@ -85,11 +90,15 @@ class StatefulBrowser(Browser):
         """Get the verbosity level. See :func:`set_verbose()`."""
         return self.__verbose
 
+    def get_page(self):
+        """Get the current page as a soup object."""
+        return self.__state.page
+
     def get_url(self):
         """Get the URL of the currently visited page."""
         return self.__state.url
 
-    def get_current_form(self):
+    def get_selected_form(self):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
@@ -104,10 +113,6 @@ class StatefulBrowser(Browser):
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
         return self.get_current_form().new_control(type, name, value, **kwargs)
-
-    def get_current_page(self):
-        """Get the current page as a soup object."""
-        return self.__state.page
 
     def absolute_url(self, url):
         """Return the absolute URL made from the current URL and ``url``.

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -19,6 +19,16 @@ def test_request_forward():
     assert r.text == 'Success!'
 
 
+def test_properties():
+    """Check that properties return the same value as the getter."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>', url="http://example.com")
+    assert browser.page == browser.get_page()
+    assert browser.url == browser.get_url()
+    browser.select_form()
+    assert browser.form == browser.get_selected_form()
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -29,6 +29,13 @@ def test_properties():
     assert browser.form == browser.get_selected_form()
 
 
+def test_get_selected_form_unselected():
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>')
+    with pytest.raises(AttributeError, match="No form has been selected yet."):
+        browser.get_selected_form()
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()


### PR DESCRIPTION
This PR combines a few changes, mostly proposed in #175.

* Deprecate longer/misleading getter names.
  `get_current_page` -> `get_page` (since there's no other page than the current one)
  `get_current_form` -> `get_selected_form` (to avoid confusion about what form this returns)

* Add properties for convenient state access
  `page` == `get_page()`
  `url` == `get_url()`
  `form` = `get_selected_form()` (rather than `selected_form` for maximum convenience)

* To combat any possible misinterpretation of the `form` property (and because I think it makes the workflow more transparent), `get_selected_form` will raise an exception if no form has been selected. I think that "Why is `browser.form` None?" is a good question to preempt.

There are a few things to decide if we want to move forward with this PR:
1. Since we are using properties, do we still want to change the getter names? I would say yes, but I'm open to alternatives.
2. Do we want complete backwards compatibility? If so, then perhaps we can consider keeping (but still deprecating) `get_current_form` with the exception-free behavior instead of aliasing it to `get_selected_form`. However, I think the exception version is safer and a fairly transparent backwards incompatibility, and I would prefer transitioning to the new version outright.
3. Since the properties are so much more convenient, should we advertise them in the docs in favor of the traditional getters?