### PR TITLE
Handles html entities that don't say they are html

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -52,15 +52,20 @@ class Browser(object):
                 self.session.mount(adaptee, adapter)
 
         self.soup_config = soup_config or dict()
-    
+
+    @staticmethod
     def __looks_like_html(response):
-        text = response.text.lstrip()
-        return text.startswith('<html') or text.startswith('<!DOCTYPE')
+        """Guesses entity type when Content-Type header is missing.
+        Since Content-Type is not strictly required, some servers leave it out.
+        """
+        text = response.text.lstrip().lower()
+        return text.startswith('<html') or text.startswith('<!doctype')
 
     @staticmethod
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
-        if "text/html" in response.headers.get("Content-Type", "") or __looks_like_html(response):
+        if ("text/html" in response.headers.get("Content-Type", "")
+                or Browser.__looks_like_html(response)):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -56,7 +56,10 @@ class Browser(object):
     @staticmethod
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
-        if "text/html" in response.headers.get("Content-Type", ""):
+        text = response.text.lstrip()
+        if ("text/html" in response.headers.get("Content-Type", "") 
+                or text.startswith('<html') 
+                or text.startswith('<!DOCTYPE')):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -52,14 +52,15 @@ class Browser(object):
                 self.session.mount(adaptee, adapter)
 
         self.soup_config = soup_config or dict()
+    
+    def __looks_like_html(response):
+        text = response.text.lstrip()
+        return text.startswith('<html') or text.startswith('<!DOCTYPE')
 
     @staticmethod
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
-        text = response.text.lstrip()
-        if ("text/html" in response.headers.get("Content-Type", "") 
-                or text.startswith('<html') 
-                or text.startswith('<!DOCTYPE')):
+        if "text/html" in response.headers.get("Content-Type", "") or __looks_like_html(response):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None


### PR DESCRIPTION
One of the web servers I tried MechanicalSoup against leaves out the `Content-Type` on some HTML containing responses.
According to https://tools.ietf.org/html/rfc2616#section-7.2.1 
this is actually valid behavior and we are expected to guess if we so choose.
This changes `add_soup(response, soup_config)` to take a swag in that case.