### PR TITLE
Remove `name` attribute from all unused buttons on form submit

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -161,7 +161,7 @@ class Browser(object):
         for tag in form.select(selector):
             name = tag.get("name")  # name-attribute of tag
 
-            if tag.name in ("input", "button"):
+            if tag.name == "input":
                 if tag.get("type") in ("radio", "checkbox"):
                     if "checked" not in tag.attrs:
                         continue
@@ -182,6 +182,12 @@ class Browser(object):
                     files[name] = value
                 else:
                     data.append((name, value))
+
+            elif tag.name == "button":
+                if tag.get("type", "") in ("button", "reset"):
+                    continue
+                else:
+                    data.append((name, tag.get("value", "")))
 
             elif tag.name == "textarea":
                 data.append((name, tag.text))

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -304,11 +304,19 @@ class Form(object):
             browser.submit_selected()
         """
 
+        submit = (
+            submit or
+            self.form.select_one('input[type="submit"]') or
+            self.form.select_one('button[type="submit"]')
+        )
+
         found = False
-        inps = self.form.select('input[type="submit"], button[type="submit"]')
+        inps = self.form.select('input[type="submit"], button')
         for inp in inps:
-            if inp == submit or (inp.has_attr('name') and
-                                 inp['name'] == submit):
+            if inp.get('type', "").lower() not in ("button", "reset") and (
+                inp == submit or (inp.has_attr('name') and
+                                  inp['name'] == submit)
+            ):
                 if found:
                     raise LinkNotFoundError(
                         "Multiple submit elements match: {0}".format(submit)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -218,8 +218,7 @@ class StatefulBrowser(Browser):
         to :func:`Form.choose_submit` on the current form to choose between
         them. All other arguments are forwarded to :func:`Browser.submit`.
         """
-        if btnName is not None:
-            self.get_current_form().choose_submit(btnName)
+        self.get_current_form().choose_submit(btnName)
 
         referer = self.get_url()
         if referer is not None:


### PR DESCRIPTION
I ran into a site with forms including buttons of `type` "button" with `name` attributes. Because `Form.choose_submit()` was only removing `name` from buttons of `type` "submit", the values for the "button" buttons were being erroneously sent on POST, thereby breaking my submission. This patch fixes the issue, even when a submit button isn't explicitly chosen.

Note that all buttons that aren't of `type` "button" or "reset" function as "submit" in all major browsers and should therefore be choosable.