### PR TITLE
browser.py: write temporary file with .html extension

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -228,7 +228,7 @@ class Browser(object):
 
         :param: soup: Page contents to display, supplied as a bs4 soup object.
         """
-        with tempfile.NamedTemporaryFile(delete=False) as file:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as file:
             file.write(soup.encode())
         webbrowser.open('file://' + file.name)
 


### PR DESCRIPTION
Depending on the contents of the file (I think), Google Chrome may
display a file as text rather than html unless it has a .html
extension. In `launch_browser`, we typically want to look at the
rendered html of the page (otherwise we would just print the html
as text in the command line), so to ensure this happens we can
add a `.html` suffix to the temporary file.

NOTE: `launch_browser` started displaying the page contents in text for me recently after rendering the html for the same page in the past. I don't know if this is due to a different version of Chrome or due to changes in the contents of the html. Adding the `.html` suffix to the filename fixed this problem for me, but I'm not entirely sure it's the most appropriate solution.