### PR TITLE
Derive LinkNotFoundError from Exception

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,16 @@ Release Notes
 Version 1.0 (in development)
 ============================
 
+Bug fixes
+---------
+
+* **Breaking Change:** :class:`~mechanicalsoup.LinkNotFoundError` now derives
+  from ``Exception`` instead of ``BaseException``. While this will bring the
+  behavior in line with most people's expectations, it may affect the behavior
+  of your code if you were heavily relying on this implementation detail in
+  your exception handling.
+  [`#203 <https://github.com/MechanicalSoup/MechanicalSoup/issues/203>`__]
+
 Version 0.10
 ============
 

--- a/mechanicalsoup/utils.py
+++ b/mechanicalsoup/utils.py
@@ -1,4 +1,4 @@
-class LinkNotFoundError(BaseException):
+class LinkNotFoundError(Exception):
     """Exception raised when mechanicalsoup fails to find something.
 
     This happens in situations like (non-exhaustive list):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import mechanicalsoup
+import pytest
+
+
+def test_LinkNotFoundError():
+    with pytest.raises(mechanicalsoup.LinkNotFoundError):
+        raise mechanicalsoup.utils.LinkNotFoundError
+    with pytest.raises(Exception):
+        raise mechanicalsoup.utils.LinkNotFoundError


### PR DESCRIPTION
Closes #203.

The python documentation recommends to all developers that custom
exception classes should derive from `Exception` instead of
`BaseException`.

This change is not backwards compatible. Previously, a
`LinkNotFoundError` would pass through an `Exception` catch.
After this change, it would no longer pass through.