### PR TITLE
Include docs in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE README.rst
 recursive-include tests *.py
 include examples/example*.py
 include requirements.txt tests/requirements.txt
+include docs/*


### PR DESCRIPTION
We at Gentoo use the PyPI tarballs to build docs. It would be easier for us if the docs were included there.