### PR TITLE
Allow the testsuite to run on new httpbin versions

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -6,7 +6,12 @@ import mechanicalsoup
 import sys
 import re
 from bs4 import BeautifulSoup
-from utils import setup_mock_browser, prepare_mock_browser, mock_get
+from utils import (
+    setup_mock_browser,
+    prepare_mock_browser,
+    mock_get,
+    open_legacy_httpbin
+)
 import pytest
 import webbrowser
 
@@ -367,11 +372,12 @@ def test_select_form_tag_object():
 
 def test_referer_follow_link(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
-    browser.open(httpbin.url)
+    open_legacy_httpbin(browser, httpbin)
+    start_url = browser.get_url()
     response = browser.follow_link("/headers")
     referer = response.json()["headers"]["Referer"]
     actual_ref = re.sub('/*$', '', referer)
-    expected_ref = re.sub('/*$', '', httpbin.url)
+    expected_ref = re.sub('/*$', '', start_url)
     assert actual_ref == expected_ref
 
 
@@ -445,7 +451,7 @@ def file_get_contents(filename):
 def test_download_link(httpbin):
     """Test downloading the contents of a link to file."""
     browser = mechanicalsoup.StatefulBrowser()
-    browser.open(httpbin.url)
+    open_legacy_httpbin(browser, httpbin)
     tmpdir = tempfile.mkdtemp()
     tmpfile = tmpdir + '/nosuchfile.png'
     current_url = browser.get_url()
@@ -466,7 +472,7 @@ def test_download_link(httpbin):
 def test_download_link_nofile(httpbin):
     """Test downloading the contents of a link without saving it."""
     browser = mechanicalsoup.StatefulBrowser()
-    browser.open(httpbin.url)
+    open_legacy_httpbin(browser, httpbin)
     current_url = browser.get_url()
     current_page = browser.get_current_page()
     response = browser.download_link(link='image/png')
@@ -482,7 +488,7 @@ def test_download_link_nofile(httpbin):
 def test_download_link_to_existing_file(httpbin):
     """Test downloading the contents of a link to an existing file."""
     browser = mechanicalsoup.StatefulBrowser()
-    browser.open(httpbin.url)
+    open_legacy_httpbin(browser, httpbin)
     tmpdir = tempfile.mkdtemp()
     tmpfile = tmpdir + '/existing.png'
     with open(tmpfile, "w") as f:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,3 +76,20 @@ class HttpbinRemote:
 
     def __add__(self, x):
         return self.url + x
+
+
+def open_legacy_httpbin(browser, httpbin):
+    """Opens the start page of httpbin (given as a fixture). Tries the
+    legacy page (available only on recent versions of httpbin), and if
+    it fails fall back to the main page (which is JavaScript-only in
+    recent versions of httpbin hence usable for us only on old
+    versions).
+    """
+    try:
+        response = browser.open(httpbin + "/legacy")
+        if response.status_code == 404:
+            # The line above may or may not have raised the expection
+            # depending on raise_on_404. Raise it unconditionally now.
+            raise mechanicalsoup.LinkNotFoundError()
+    except mechanicalsoup.LinkNotFoundError:
+        browser.open(httpbin.url)


### PR DESCRIPTION
The new httpbin version has a JavaScript-enabled welcome page, not
suited for MechanicalSoup. Fortunately, the old version is still
available with a URL /legacy.

Use this URL, if available, for tests which need it.

Fixes #213.