### PR TITLE
Rewrite `Browser._request` to handle repeated input elements

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -15,6 +15,12 @@ Bug fixes
   your exception handling.
   [`#203 <https://github.com/MechanicalSoup/MechanicalSoup/issues/203>`__]
 
+* Improve consistency of query string construction between MechanicalSoup
+  and web browsers in edge cases where form elements have duplicate name
+  attributes. This prevents errors in valid use cases, and also makes
+  MechanicalSoup more tolerant of invalid HTML.
+  [`#158 <https://github.com/MechanicalSoup/MechanicalSoup/issues/158>`__]
+
 Version 0.10
 ============
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -187,17 +187,19 @@ class Browser(object):
                 data.append((name, tag.text))
 
             elif tag.name == "select":
-                multiple = "multiple" in tag.attrs
-                values = []
-                for i, option in enumerate(tag.select("option")):
-                    if (i == 0 and not multiple) or "selected" in option.attrs:
-                        values.append(option.get("value", ""))
-                if multiple:
-                    for value in values:
+                options = tag.select("option")
+                selected_values = [i.get("value", "") for i in options
+                                   if "selected" in i.attrs]
+                if "multiple" in tag.attrs:
+                    for value in selected_values:
                         data.append((name, value))
-                elif values:
+                elif selected_values:
+                    # A standard select element only allows one option to be
+                    # selected, but browsers pick last if somehow multiple.
+                    data.append((name, selected_values[-1]))
+                elif options:
                     # Selects the first option if none are selected
-                    data.append((name, values[-1]))
+                    data.append((name, options[0].get("value", "")))
 
         if method.lower() == "get":
             kwargs["params"] = data

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -109,6 +109,23 @@ def test__request_file(httpbin):
     assert "multipart/form-data" in response.request.headers["Content-Type"]
 
 
+def test__request_select_none(httpbin):
+    """Make sure that a <select> with no options selected
+    submits the first option, as it does in a browser."""
+    form_html = """
+    <form method="post" action={}/post>
+      <select name="shape">
+        <option value="round">Round</option>
+        <option value="square">Square</option>
+      </select>
+    </form>""".format(httpbin.url)
+
+    form = BeautifulSoup(form_html, "lxml").form
+    browser = mechanicalsoup.Browser()
+    response = browser._request(form)
+    assert response.json()['form'] == {'shape': 'round'}
+
+
 def test_no_404(httpbin):
     browser = mechanicalsoup.Browser()
     resp = browser.get(httpbin + "/nosuchpage")

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -366,5 +366,26 @@ def test_issue180():
         form.choose_submit('not_found')
 
 
+def test_issue158():
+    """Test that form elements are processed in their order on the page
+    and that elements with duplicate name-attributes are not clobbered."""
+    issue158_form = '''
+<form method="post" action="mock://form.com/post">
+  <input name="box" type="hidden" value="1"/>
+  <input checked="checked" name="box" type="checkbox" value="2"/>
+  <input name="box" type="hidden" value="0"/>
+  <input type="submit" value="Submit" />
+</form>
+'''
+    expected_post = [('box', '1'), ('box', '2'), ('box', '0')]
+    browser, url = setup_mock_browser(expected_post=expected_post,
+                                      text=issue158_form)
+    browser.open(url)
+    browser.select_form()
+    res = browser.submit_selected()
+    assert(res.status_code == 200 and res.text == 'Success!')
+    browser.close()
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -235,9 +235,9 @@ def test_set_select_multiple(options):
     # When a browser submits multiple selections, the qsl looks like:
     #  name=option1&name=option2
     if not isinstance(options, list) and not isinstance(options, tuple):
-        expected = (('instrument', options),)
+        expected = [('instrument', options)]
     else:
-        expected = (('instrument', option) for option in options)
+        expected = [('instrument', option) for option in options]
     browser, url = setup_mock_browser(expected_post=expected,
                                       text=set_select_multiple_form)
     browser.open(url)

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -17,10 +17,9 @@ import webbrowser
 
 
 def test_request_forward():
-    browser, url = setup_mock_browser(expected_post=[('var1', 'val1'),
-                                                     ('var2', 'val2')])
-    r = browser.request('POST', url + '/post', data={'var1': 'val1',
-                                                     'var2': 'val2'})
+    data = [('var1', 'val1'), ('var2', 'val2')]
+    browser, url = setup_mock_browser(expected_post=data)
+    r = browser.request('POST', url + '/post', data=data)
     assert r.text == 'Success!'
 
 
@@ -302,8 +301,8 @@ submit_form_multiple = '''
 
 
 def test_form_multiple():
-    browser, url = setup_mock_browser(expected_post=[('foo', 'tempeh'),
-                                                     ('foo', 'tofu')])
+    browser, url = setup_mock_browser(expected_post=[('foo', 'tofu'),
+                                                     ('foo', 'tempeh')])
     browser.open_fake_page(submit_form_multiple, url=url)
     browser.select_form('#choose-submit-form')
     response = browser.submit_selected()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,8 +61,8 @@ def mock_get(mocked_adapter, url, reply, content_type='text/html', **kwargs):
 def mock_post(mocked_adapter, url, expected, reply='Success!'):
     def text_callback(request, context):
         # Python 2's parse_qsl doesn't like None argument
-        query = parse_qsl(request.text) if request.text else ()
-        assert (set(query) == set(expected))
+        query = parse_qsl(request.text) if request.text else []
+        assert (query == expected)
         return reply
 
     mocked_adapter.register_uri('POST', url, text=text_callback)


### PR DESCRIPTION
Improve consistency of query string construction between
MechanicalSoup and web browsers in edge cases where form elements
have duplicate *name*-attributes.

For example, if a form with the following is submitted:

```
<input name="key" value="val1" />
<input name="key" value="val2" />
```

Then the resulting query string will now be

```
key=val1&key=val2
```

instead of

```
key=val2
```

More detail
===========

Store data to be encoded in the query string in a list of 2-tuples
instead of a dictionary. In doing so, we allow for the possibility
of multiple form elements being submitted with the same name.

Surprisingly, this is legal HTML (though sometimes unintentional),
so we want to be as faithful as possible to how the query string for
such a form would be created in a real browser.

To do this, we need to process the form elements in the order that
they appear on the page, rather than grouping them by type (which
is what we were doing when we stored the data in a dict).

This change allows us to accept any (name,value) combinations at
any point in the page without worrying about handling name conflicts
or whether to store a single value or a list of values -- because
now every bit of data is simply appended to the list of 2-tuples.

Ultimately, this means that the method is now agnostic to the
validity of the form data. While the `Form` class will still prevent
most illegal form manipulations, it has no control over HTML that
is malformed when it is served. There are some fringe cases where
malformed form HTML would cause MechanicalSoup to throw, but will
now submit the data as-is just like a browser would.

Note: We have simplified some of the logic by changing the bs4
selector to restrict to tags with name-attributes for all tag-types
(previously it only made this restriction for `input` and `button`,
even though it still ignored name-less `textarea` and `select`).

---------------------
This replaces PR's #159 and #160 with a, hopefully, more generic
solution to the issue. The `Browser._request` internals are still more
complicated than I'd like them to be, but I think this change at least
handles everything more consistently.