### PR TITLE
form.py: print button elements in print_summary

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -329,7 +329,7 @@ class Form(object):
         May help finding which fields need to be filled-in.
         """
         for input in self.form.find_all(
-                ("input", "textarea", "select")):
+                ("input", "textarea", "select", "button")):
             input_copy = copy.copy(input)
             # Text between the opening tag and the closing tag often
             # contains a lot of spaces that we don't want here.

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -336,6 +336,7 @@ page_with_various_fields = '''
     <p><input name="size" type=radio value="small">Small</p>
     <p><input name="size" type=radio value="medium">Medium</p>
     <p><input name="size" type=radio value="large">Large</p>
+    <button name="action"  value="cancel">Cancel</button>
     <input type="submit" value="Select" />
   </form>
 </html>
@@ -366,6 +367,7 @@ def test_form_print_summary(capsys):
 <input name="size" type="radio" value="small"/>
 <input name="size" type="radio" value="medium"/>
 <input name="size" type="radio" value="large"/>
+<button name="action" value="cancel">Cancel</button>
 <input type="submit" value="Select"/>
 """
     assert err == ""


### PR DESCRIPTION
Since some button elements are submittable, it is important to
print them in the summary. We do not differentiate between button
types when printing since this is only a diagnostic method.