### PR TITLE
form.py: must construct forms from form elements

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -33,6 +33,9 @@ class Form(object):
     """
 
     def __init__(self, form):
+        if form.name != 'form':
+            raise LinkNotFoundError('Must construct a Form from a form '
+                                    'element, not {}'.format(form.name))
         self.form = form
 
         # Aliases for backwards compatibility

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -193,8 +193,6 @@ class StatefulBrowser(Browser):
             retrieved later with :func:`get_current_form`.
         """
         if isinstance(selector, bs4.element.Tag):
-            if selector.name != "form":
-                raise LinkNotFoundError()
             self.__state.form = Form(selector)
         else:
             # nr is a 0-based index for consistency with mechanize

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,8 +1,18 @@
 import setpath  # noqa:F401, must come before 'import mechanicalsoup'
 import mechanicalsoup
+import bs4
 from utils import setup_mock_browser
 import sys
 import pytest
+
+
+def test_construct_form_fail():
+    """Form objects must be constructed from form html elements."""
+    soup = bs4.BeautifulSoup('<notform>This is not a form</notform>', 'lxml')
+    tag = soup.find('notform')
+    assert isinstance(tag, bs4.element.Tag)
+    with pytest.raises(mechanicalsoup.LinkNotFoundError):
+        mechanicalsoup.Form(tag)
 
 
 def test_submit_online(httpbin):


### PR DESCRIPTION
Form construction and `select_form` will now raise a LinkNotFoundError
when passed a bs4.element.Tag _or_ a CSS selector that is not for a
`form` element.

Previously, this was enforced inconsistently, only raising when
`select_form` was passed an invalid bs4.element.Tag.