### PR TITLE
CONTRIBUTING.rst: new packaging instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,19 +94,47 @@ At each release:
   <https://github.com/MechanicalSoup/MechanicalSoup/releases>`__, copy
   the relevant section from ``docs/ChangeLog.rst`` to the release
   page.
-- ``python setup.py sdist upload -r pypi`` or ``twine upload``. This
-  requires a ``~/.pypirc`` with::
+- Upload the distribution (see the `Python Packaging Guide
+  <https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives>`__
+  for details). First, install any needed dependencies::
+
+    pip install --upgrade setuptools wheel twine
+
+  Then locally prepare the distribution::
+
+    python setup.py sdist bdist_wheel
+
+  Use the following ``~/.pypirc`` (if you omit the ``username`` and
+  ``password`` fields for security, you will be prompted for them during
+  the upload)::
 
     [distutils]
     index-servers =
         pypi
-    
-    [pypi]
-    username:<user>
-    password:<password>
+        test
 
-- Check on https://pypi.python.org/pypi/MechanicalSoup/, and verify
-  installation from PyPI with `pip install --no-cache-dir mechanicalsoup`.
+    [test]
+    repository = https://test.pypi.org/legacy/
+    username = <username>
+    password = <password>
+
+    [pypi]
+    repository = https://pypi.python.org/pypi
+    username = <username>
+    password = <password>
+
+  Upload the distribution to Test PyPI::
+
+    twine upload -r test dist/*
+
+  Once you verify that it is correct on `test.pypi.org
+  <https://test.pypi.org/project/MechanicalSoup/>`__ and make any necessary
+  fixes for the official distribution, you are ready to release::
+
+    twine upload -r pypi dist/*
+
+- Check on https://pypi.org/project/MechanicalSoup/, and verify
+  installation from PyPI with ``pip install --no-cache-dir mechanicalsoup``.
 
 Right after the release:
 


### PR DESCRIPTION
* Distribute both Wheel and Source
* Add a step to test distribution on test.pypi.org
* Add explicit twine instructions (and drop setup.py alternative)
  because Python recommends using it for uploads to PyPI.

Closes #225.

Instructions have been tested up to the official upload to PyPI.