### PR TITLE
test_form.py: fix test_choose_submit_twice

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -156,7 +156,8 @@ def test_choose_submit_twice():
       <input type="submit" name="test2" value="Test2" />
     </form>
     '''
-    form = mechanicalsoup.Form(bs4.BeautifulSoup(text, 'lxml'))
+    soup = bs4.BeautifulSoup(text, 'lxml')
+    form = mechanicalsoup.Form(soup.form)
     form.choose_submit('test1')
     expected_msg = 'Submit already chosen. Cannot change submit!'
     with pytest.raises(Exception, match=expected_msg):


### PR DESCRIPTION
When a BeautifulSoup object is constructed from an html string,
it will standardize the html. In this case, since the input html
was just a raw `<form>`, it added `<html>` and `<body>` tags around it.

Since the `Form` ctor now demands that it is passed a `<form>` element,
we need to extract `<form>` from the object BeautifulSoup constructs
to pass to the `Form` ctor.

-----------------

Side question: The sanity check on `Form` being passed a `<form>` is in principle a good one, since I have seen plenty of errors that resulted from passing something that wasn't (or didn't even contain) a form to the `Form` ctor. But is it too restrictive? Should we expect that passing a `<html><body><form>...</form></body></html>` to `Form` should work? And if so, could we allow such a thing without also letting people make more egregious mistakes?