### PR TITLE
form.py: relax error to deprecation warning

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import copy
+import warnings
 from .utils import LinkNotFoundError
 from bs4 import BeautifulSoup
 
@@ -34,8 +35,11 @@ class Form(object):
 
     def __init__(self, form):
         if form.name != 'form':
-            raise LinkNotFoundError('Must construct a Form from a form '
-                                    'element, not {}'.format(form.name))
+            warnings.warn(
+                "Constructed a Form from a '{}' instead of a 'form' element. "
+                "This may be an error in a future version of MechanicalSoup.",
+                PendingDeprecationWarning)
+
         self.form = form
         self._submit_chosen = False
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -193,6 +193,8 @@ class StatefulBrowser(Browser):
             retrieved later with :func:`get_current_form`.
         """
         if isinstance(selector, bs4.element.Tag):
+            if selector.name != "form":
+                raise LinkNotFoundError
             self.__state.form = Form(selector)
         else:
             # nr is a 0-based index for consistency with mechanize

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -11,8 +11,7 @@ def test_construct_form_fail():
     soup = bs4.BeautifulSoup('<notform>This is not a form</notform>', 'lxml')
     tag = soup.find('notform')
     assert isinstance(tag, bs4.element.Tag)
-    with pytest.raises(mechanicalsoup.LinkNotFoundError):
-        mechanicalsoup.Form(tag)
+    pytest.deprecated_call(mechanicalsoup.Form, tag)
 
 
 def test_submit_online(httpbin):


### PR DESCRIPTION
In 4e3fd3cdda9a, passing a bs4.element.Tag that was not a "form"
to the constructor of `Form` was escalated to a `LinkNotFoundError`.

Since this breaks backwards compatibility, we soften the error to
a deprecation warning (using the warnings library). In a future
version, this may become an error again.

However, `StatefulBrowser.select_form` has always raised an error
in this case since it began accepting a bs4.element.Tag in a5dec341,
so we continue to do so there.

Related to #228.