### PR TITLE
browser.py: add StatefulBrowser note in submit docstring

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -218,6 +218,10 @@ class Browser(object):
     def submit(self, form, url=None, **kwargs):
         """Prepares and sends a form request.
 
+        NOTE: To submit a form with a :class:`StatefulBrowser` instance, it is
+        recommended to use :func:`StatefulBrowser.submit_selected` instead of
+        this method so that the browser state is correctly updated.
+
         :param form: The filled-out form.
         :param url: URL of the page the form is on. If the form action is a
             relative path, then this must be specified.


### PR DESCRIPTION
This docstring note is a necessary (but probably not sufficient)
change to `Browser.submit` to prevent it from being used in an
inappropriate way from a `StatefulBrowser` instance.

See #230 and #233 for more info.

![image](https://user-images.githubusercontent.com/846186/45237163-caab6680-b292-11e8-8995-c65af9236bc9.png)
