### PR TITLE
handle <option> tag without value option

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -206,7 +206,8 @@ class Browser(object):
                     data.append((name, selected_values[-1]))
                 elif options:
                     # Selects the first option if none are selected
-                    data.append((name, options[0].get("value", options[0].text)))
+                    data.append((name, options[0].get("value",
+                                                      options[0].text)))
 
         if method.lower() == "get":
             kwargs["params"] = data

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -195,7 +195,7 @@ class Browser(object):
 
             elif tag.name == "select":
                 options = tag.select("option")
-                selected_values = [i.get("value", "") for i in options
+                selected_values = [i.get("value", i.text) for i in options
                                    if "selected" in i.attrs]
                 if "multiple" in tag.attrs:
                     for value in selected_values:
@@ -206,7 +206,7 @@ class Browser(object):
                     data.append((name, selected_values[-1]))
                 elif options:
                     # Selects the first option if none are selected
-                    data.append((name, options[0].get("value", "")))
+                    data.append((name, options[0].get("value", options[0].text)))
 
         if method.lower() == "get":
             kwargs["params"] = data

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -216,6 +216,14 @@ class Form(object):
 
             for choice in value:
                 option = select.find("option", {"value": choice})
+
+                # try to find with text instead of value
+                if not option:
+                  option = select.find("option", string=choice)
+
+                  if not option:
+                    raise LinkNotFoundError('Option %s not found for select %s' % (choice, name))
+
                 option.attrs["selected"] = "selected"
 
     def __setitem__(self, name, value):

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -221,10 +221,10 @@ class Form(object):
                 if not option:
                     option = select.find("option", string=choice)
 
-                    if not option:
-                        raise LinkNotFoundError(
-                          'Option %s not found for select %s' % (choice, name)
-                        )
+                if not option:
+                    raise LinkNotFoundError(
+                        'Option %s not found for select %s' % (choice, name)
+                    )
 
                 option.attrs["selected"] = "selected"
 

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -219,10 +219,12 @@ class Form(object):
 
                 # try to find with text instead of value
                 if not option:
-                  option = select.find("option", string=choice)
+                    option = select.find("option", string=choice)
 
-                  if not option:
-                    raise LinkNotFoundError('Option %s not found for select %s' % (choice, name))
+                    if not option:
+                        raise LinkNotFoundError(
+                          'Option %s not found for select %s' % (choice, name)
+                        )
 
                 option.attrs["selected"] = "selected"
 


### PR DESCRIPTION
&lt;option&gt; tags can omit the value option, in this case the text of the
option is used, cf : 
https://www.w3schools.com/tags/att_option_value.asp

> Note: If the value attribute is not specified, the content will be passed as a value instead.