### PR TITLE
handle <option> tag without value option with tests

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -195,7 +195,7 @@ class Browser(object):
 
             elif tag.name == "select":
                 options = tag.select("option")
-                selected_values = [i.get("value", "") for i in options
+                selected_values = [i.get("value", i.text) for i in options
                                    if "selected" in i.attrs]
                 if "multiple" in tag.attrs:
                     for value in selected_values:
@@ -206,7 +206,8 @@ class Browser(object):
                     data.append((name, selected_values[-1]))
                 elif options:
                     # Selects the first option if none are selected
-                    data.append((name, options[0].get("value", "")))
+                    data.append((name, options[0].get("value",
+                                                      options[0].text)))
 
         if method.lower() == "get":
             kwargs["params"] = data

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -194,6 +194,8 @@ class Browser(object):
                 data.append((name, tag.text))
 
             elif tag.name == "select":
+                # If the value attribute is not specified, the content will
+                # be passed as a value instead.
                 options = tag.select("option")
                 selected_values = [i.get("value", i.text) for i in options
                                    if "selected" in i.attrs]
@@ -206,8 +208,8 @@ class Browser(object):
                     data.append((name, selected_values[-1]))
                 elif options:
                     # Selects the first option if none are selected
-                    data.append((name, options[0].get("value",
-                                                      options[0].text)))
+                    first_value = options[0].get("value", options[0].text)
+                    data.append((name, first_value))
 
         if method.lower() == "get":
             kwargs["params"] = data

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -216,6 +216,16 @@ class Form(object):
 
             for choice in value:
                 option = select.find("option", {"value": choice})
+
+                # try to find with text instead of value
+                if not option:
+                    option = select.find("option", string=choice)
+
+                if not option:
+                    raise LinkNotFoundError(
+                        'Option %s not found for select %s' % (choice, name)
+                    )
+
                 option.attrs["selected"] = "selected"
 
     def __setitem__(self, name, value):

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -193,9 +193,10 @@ class Form(object):
         :param data: Dict of ``{name: value, ...}``.
             Find the select element whose *name*-attribute is ``name``.
             Then select from among its children the option element whose
-            *value*-attribute is ``value``. If the select element's
-            *multiple*-attribute is set, then ``value`` can be a list
-            or tuple to select multiple options.
+            *value*-attribute is ``value``. If no matching *value*-attribute
+            is found, this will search for an option whose text matches
+            ``value``. If the select element's *multiple*-attribute is set,
+            then ``value`` can be a list or tuple to select multiple options.
         """
         for (name, value) in data.items():
             select = self.form.find("select", {"name": name})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests >= 2.0
-beautifulsoup4
+beautifulsoup4 >= 4.4
 six >= 1.4
 lxml

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -467,20 +467,18 @@ def test_choose_submit_buttons(expected_post):
                  id='Option with value selected by its text'),
     pytest.param(True, 'Unknown option', None,
                  id='Unknown option, must raise a LinkNotFound exception')
-
 ])
 def test_option_without_value(fail, selected, expected_post):
     """Option tag in select can have no value option"""
     text = """
     <form method="post" action="mock://form.com/post">
-<select name="selector">
-<option value="with_value">We have a value here</option>
-<option>Without value</option>
-</select>
-<button type="submit">Submit</button>
-</form>
-"""
-    expected_post = expected_post
+      <select name="selector">
+        <option value="with_value">We have a value here</option>
+        <option>Without value</option>
+      </select>
+      <button type="submit">Submit</button>
+    </form>
+    """
     browser, url = setup_mock_browser(expected_post=expected_post,
                                       text=text)
     browser.open(url)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -458,5 +458,42 @@ def test_choose_submit_buttons(expected_post):
     assert res.status_code == 200 and res.text == 'Success!'
 
 
+@pytest.mark.parametrize("fail, selected, expected_post", [
+    pytest.param(False, 'with_value', [('selector', 'with_value')],
+                 id='Option with value'),
+    pytest.param(False, 'Without value', [('selector', 'Without value')],
+                 id='Option without value'),
+    pytest.param(False, 'We have a value here', [('selector', 'with_value')],
+                 id='Option with value selected by its text'),
+    pytest.param(True, 'Unknown option', None,
+                 id='Unknown option, must raise a LinkNotFound exception')
+
+])
+def test_option_without_value(fail, selected, expected_post):
+    """Option tag in select can have no value option"""
+    text = """
+    <form method="post" action="mock://form.com/post">
+<select name="selector">
+<option value="with_value">We have a value here</option>
+<option>Without value</option>
+</select>
+<button type="submit">Submit</button>
+</form>
+"""
+    expected_post = expected_post
+    browser, url = setup_mock_browser(expected_post=expected_post,
+                                      text=text)
+    browser.open(url)
+    browser.select_form()
+    if fail:
+        with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+            browser['selector'] = selected
+    else:
+        browser['selector'] = selected
+
+        res = browser.submit_selected()
+        assert res.status_code == 200 and res.text == 'Success!'
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
&lt;option&gt; tags can omit the value option, in this case the text of the
option is used, cf : 
https://www.w3schools.com/tags/att_option_value.asp

> Note: If the value attribute is not specified, the content will be passed as a value instead.