### PR TITLE
Fix tests for bs4 4.7.0+

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -74,30 +74,30 @@ def test_submit_set(httpbin):
 @pytest.mark.parametrize("expected_post", [
     pytest.param(
         [
+            ('text', 'Setting some text!'),
             ('comment', 'Testing preview page'),
             ('preview', 'Preview Page'),
-            ('text', 'Setting some text!')
         ], id='preview'),
     pytest.param(
         [
+            ('text', '= Heading =\n\nNew page here!\n'),
             ('comment', 'Created new page'),
             ('save', 'Submit changes'),
-            ('text', '= Heading =\n\nNew page here!\n')
         ], id='save'),
     pytest.param(
         [
+            ('text', '= Heading =\n\nNew page here!\n'),
             ('comment', 'Testing choosing cancel button'),
             ('cancel', 'Cancel'),
-            ('text', '= Heading =\n\nNew page here!\n')
         ], id='cancel'),
 ])
 def test_choose_submit(expected_post):
     browser, url = setup_mock_browser(expected_post=expected_post)
     browser.open(url)
     form = browser.select_form('#choose-submit-form')
-    browser['text'] = expected_post[2][1]
-    browser['comment'] = expected_post[0][1]
-    form.choose_submit(expected_post[1][0])
+    browser['text'] = dict(expected_post)['text']
+    browser['comment'] = dict(expected_post)['comment']
+    form.choose_submit(expected_post[2][0])
     res = browser.submit_selected()
     assert(res.status_code == 200 and res.text == 'Success!')
 

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -125,15 +125,15 @@ def test_links():
 @pytest.mark.parametrize("expected_post", [
     pytest.param(
         [
+            ('text', 'Setting some text!'),
             ('comment', 'Selecting an input submit'),
             ('diff', 'Review Changes'),
-            ('text', 'Setting some text!')
         ], id='input'),
     pytest.param(
         [
+            ('text', '= Heading =\n\nNew page here!\n'),
             ('comment', 'Selecting a button submit'),
             ('cancel', 'Cancel'),
-            ('text', '= Heading =\n\nNew page here!\n')
         ], id='button'),
 ])
 def test_submit_btnName(expected_post):
@@ -141,9 +141,9 @@ def test_submit_btnName(expected_post):
     browser, url = setup_mock_browser(expected_post=expected_post)
     browser.open(url)
     browser.select_form('#choose-submit-form')
-    browser['text'] = expected_post[2][1]
-    browser['comment'] = expected_post[0][1]
-    res = browser.submit_selected(btnName=expected_post[1][0])
+    browser['text'] = dict(expected_post)['text']
+    browser['comment'] = dict(expected_post)['comment']
+    res = browser.submit_selected(btnName=expected_post[2][0])
     assert(res.status_code == 200 and res.text == 'Success!')
 
 


### PR DESCRIPTION
CSS selectors in bs4 now return elements in page order, whereas
they did not previously.

This requires us to re-order some of our expected test output,
and to perform an order-independent comparison if tested with
a bs4 version before 4.7.0.

Tested and passing with bs4 4.6.0 and 4.7.1.

Closes #257.