### PR TITLE
Improve `test_link_arg_*` tests

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -421,18 +421,18 @@ def test_referer_submit_headers(httpbin):
     assert headers['X-Test-Header'] == 'x-test-value'
 
 
-def test_link_arg_text(httpbin):
+@pytest.mark.parametrize('expected, kwargs', [
+    pytest.param('/foo', {}, id='none'),
+    pytest.param('/get', {'text': 'Link'}, id='text'),
+    pytest.param('/get', {'url_regex': 'get'}, id='regex',
+                 marks=pytest.mark.xfail),
+])
+def test_follow_link_arg(httpbin, expected, kwargs):
     browser = mechanicalsoup.StatefulBrowser()
-    browser.open_fake_page('<a href="/get">Link</a>', httpbin.url)
-    browser.follow_link(link_text='Link')
-    assert browser.get_url() == httpbin + '/get'
-
-
-def test_link_arg_regex(httpbin):
-    browser = mechanicalsoup.StatefulBrowser()
-    browser.open_fake_page('<a href="/get">Link</a>', httpbin.url)
-    browser.follow_link(url_regex='.*')
-    assert browser.get_url() == httpbin + '/get'
+    html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
+    browser.open_fake_page(html, httpbin.url)
+    browser.follow_link(**kwargs)
+    assert browser.get_url() == httpbin + expected
 
 
 def test_link_arg_multiregex(httpbin):


### PR DESCRIPTION
The `test_link_arg_regex` test was accidentally passing. By adding
another link to the test html, we can see that it was selecting the
first link instead of the link that matched the supplied regex.
This new version of the test fails, but it will be fixed by #256.

Also added a case for no arguments and reduced code duplication
by changing it to a parameterized test.

I'm not sure what way would be best to merge this in, since it should
come before #256 (to demonstrate the existing failure), but we probably
don't want the master branch to be failing for an extended period of time.
Any thoughts?