### PR TITLE
Fixing issue of duplicate submit buttons

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -344,12 +344,17 @@ class Form(object):
 
         found = False
         for inp in inps:
-            if inp == submit or (inp.has_attr('name') and
-                                 inp['name'] == submit):
+            if (inp.has_attr('name') and inp['name'] == submit):
                 if found:
                     raise LinkNotFoundError(
                         "Multiple submit elements match: {0}".format(submit)
                     )
+                found = True
+            # Ignore submit element since it is an exact duplicate of
+            # the one we're looking at.
+            elif inp == submit:
+                if found:
+                    del inp['name']
                 found = True
             else:
                 # Delete any non-matching element's name so that it will be

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -467,6 +467,26 @@ def test_issue158():
     browser.close()
 
 
+def test_duplicate_submit_buttons():
+    """Tests that duplicate submits doesn't break form submissions
+    See issue https://github.com/MechanicalSoup/MechanicalSoup/issues/264"""
+    issue264_form = '''
+<form method="post" action="mock://form.com/post">
+  <input name="box" type="hidden" value="1"/>
+  <input name="search" type="submit" value="Search"/>
+  <input name="search" type="submit" value="Search"/>
+</form>
+'''
+    expected_post = [('box', '1'), ('search', 'Search')]
+    browser, url = setup_mock_browser(expected_post=expected_post,
+                                      text=issue264_form)
+    browser.open(url)
+    browser.select_form()
+    res = browser.submit_selected()
+    assert(res.status_code == 200 and res.text == 'Success!')
+    browser.close()
+
+
 @pytest.mark.parametrize("expected_post", [
     pytest.param([('sub2', 'val2')], id='submit button'),
     pytest.param([('sub4', 'val4')], id='typeless button'),


### PR DESCRIPTION
Suggested fix for #264

I broke up the `if` statement to separate the logic of matching by name attribute string versus matching by `Tag`.

