### PR TITLE
Do not submit disabled form elements

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,16 @@ Release Notes
 Version 1.0 (in development)
 ============================
 
+Bug fixes
+---------
+
+* Form controls with the ``disabled`` attribute will no longer be submitted
+  to improve compliance with the HTML standard. If you were relying on this
+  bug to submit disabled elements, you can still achieve this by deleting the
+  ``disabled`` attribute from the element in the :class:`~mechanicalsoup.Form`
+  object directly.
+  [`#248 <https://github.com/MechanicalSoup/MechanicalSoup/issues/248>`__]
+
 Version 0.11
 ============
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -162,6 +162,10 @@ class Browser(object):
         for tag in form.select(selector):
             name = tag.get("name")  # name-attribute of tag
 
+            # Skip disabled elements, since they should not be submitted.
+            if tag.has_attr('disabled'):
+                continue
+
             if tag.name == "input":
                 if tag.get("type", "").lower() in ("radio", "checkbox"):
                     if "checked" not in tag.attrs:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -129,6 +129,18 @@ def test__request_select_none(httpbin):
     assert response.json()['form'] == {'shape': 'round'}
 
 
+def test__request_disabled_attr(httpbin):
+    """Make sure that disabled form controls are not submitted."""
+    form_html = """
+    <form method="post" action="{}/post">
+      <input disabled name="nosubmit" value="1" />
+    </form>""".format(httpbin.url)
+
+    browser = mechanicalsoup.Browser()
+    response = browser._request(BeautifulSoup(form_html, "lxml").form)
+    assert response.json()['form'] == {}
+
+
 def test_no_404(httpbin):
     browser = mechanicalsoup.Browser()
     resp = browser.get(httpbin + "/nosuchpage")


### PR DESCRIPTION
Closes #248.

MechanicalSoup was incorrectly ignoring `disabled` attributes
in form elements.