### PR TITLE
Add support to input type "image"

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -334,6 +334,7 @@ class Form(object):
 
         # All buttons NOT of type (button,reset) are valid submits
         inps = (self.find_by_type("input", "submit", dict()) +
+                self.find_by_type("input", "image", dict()) +
                 self.form.find_all("button"))
         inps = [i for i in inps
                 if i.get('type', '').lower() not in ('button', 'reset')]

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -128,9 +128,10 @@ def test_choose_submit_from_selector_submit(value):
     pytest.param('cancel', id='second'),
 ])
 def test_choose_submit_from_selector_image(value):
-    """Test choose_submit by passing a CSS selector argument for a input type image.
-    This test aims to ensure that inputs with type image are found, regardless its repetition.
-    Based in part of this issue: https://github.com/MechanicalSoup/MechanicalSoup/issues/201
+    """Test choose_submit by passing a CSS selector arg for a input type image.
+    This test aims to ensure that inputs with type image are found,
+    regardless its repetition.
+    Issue: https://github.com/MechanicalSoup/MechanicalSoup/issues/201
     """
     text = """
     <form method="post" action="mock://form.com/post">

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -128,7 +128,10 @@ def test_choose_submit_from_selector_submit(value):
     pytest.param('cancel', id='second'),
 ])
 def test_choose_submit_from_selector_image(value):
-    """Test choose_submit by passing a CSS selector argument."""
+    """Test choose_submit by passing a CSS selector argument for a input type image.
+    This test aims to ensure that inputs with type image are found, regardless its repetition.
+    Based in part of this issue: https://github.com/MechanicalSoup/MechanicalSoup/issues/201
+    """
     text = """
     <form method="post" action="mock://form.com/post">
       <input type="image" name="do" value="continue" />

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -106,12 +106,33 @@ def test_choose_submit(expected_post):
     pytest.param('continue', id='first'),
     pytest.param('cancel', id='second'),
 ])
-def test_choose_submit_from_selector(value):
+def test_choose_submit_from_selector_submit(value):
     """Test choose_submit by passing a CSS selector argument."""
     text = """
     <form method="post" action="mock://form.com/post">
       <input type="submit" name="do" value="continue" />
       <input type="submit" name="do" value="cancel" />
+    </form>"""
+    browser, url = setup_mock_browser(expected_post=[('do', value)], text=text)
+    browser.open(url)
+    form = browser.select_form()
+    submits = form.form.select('input[value="{}"]'.format(value))
+    assert len(submits) == 1
+    form.choose_submit(submits[0])
+    res = browser.submit_selected()
+    assert res.status_code == 200 and res.text == 'Success!'
+
+
+@pytest.mark.parametrize("value", [
+    pytest.param('continue', id='first'),
+    pytest.param('cancel', id='second'),
+])
+def test_choose_submit_from_selector_image(value):
+    """Test choose_submit by passing a CSS selector argument."""
+    text = """
+    <form method="post" action="mock://form.com/post">
+      <input type="image" name="do" value="continue" />
+      <input type="image" name="do" value="cancel" />
     </form>"""
     browser, url = setup_mock_browser(expected_post=[('do', value)], text=text)
     browser.open(url)


### PR DESCRIPTION
This PR intents to add support to inputs with type "image". Currently, Form only seeks "submit inputs" and buttons. I've added the search of "image submits". 

This PR is also based on this [issue](https://github.com/MechanicalSoup/MechanicalSoup/issues/201). 