### PR TITLE
Submit an empty file when leaving a file input blank

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -14,6 +14,10 @@ Bug fixes
   ``disabled`` attribute from the element in the :class:`~mechanicalsoup.Form`
   object directly.
   [`#248 <https://github.com/MechanicalSoup/MechanicalSoup/issues/248>`__]
+* Upon submitting a form containing a file input field without uploading one,
+  an empty filename & content will be sent in compliance with regular web
+  browser behavior.
+  [`#250 <https://github.com/MechanicalSoup/MechanicalSoup/issues/250>`__]
 
 Version 0.11
 ============

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -180,11 +180,14 @@ class Browser(object):
                     # in browsers, file upload only happens if the form
                     # (or submit button) enctype attribute is set to
                     # "multipart/form-data". We don't care, simplify.
-                    if not value:
-                        continue
-                    if isinstance(value, string_types):
-                        value = open(value, "rb")
-                    files[name] = value
+                    filename = value
+                    if filename != "" and isinstance(filename, string_types):
+                        content = open(filename, "rb")
+                    else:
+                        content = ""
+                    # If value is the empty string, we still pass it for
+                    # consistency with browsers (see #250).
+                    files[name] = (filename, content)
                 else:
                     data.append((name, value))
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -56,7 +56,6 @@ def test__request(httpbin):
         <p><input type=checkbox name="topping" value="onion" checked>Onion</p>
         <p><input type=checkbox name="topping" value="mushroom">Mushroom</p>
       </fieldset>
-      <input name="pic" type="FiLe">
       <select name="shape">
         <option value="round">Round</option>
         <option value="square" selected>Square</option>


### PR DESCRIPTION
This is in regards to issue #250 

For the tests, I followed @moy 's train of thought : 

- they are basically a copy+paste without the creation of a temp file
- `assert value["doc"] == ""` checks that the response contains an empty file

Thought a different test definition was necessary, was I right to assume so ?

In `browser.py`, I changed the `continue` around [line 179](https://github.com/MechanicalSoup/MechanicalSoup/blob/685eb6e1396008a0b3881bea5bcc6b7119f61642/mechanicalsoup/browser.py#L179) to something similar to what has been done in `test__request_file` [here](https://github.com/MechanicalSoup/MechanicalSoup/blob/685eb6e1396008a0b3881bea5bcc6b7119f61642/tests/test_browser.py#L93)

There are 2 `Add no file input submit test` commits : the second one is simply a clean up of some commented code. Will avoid it next time !

I was unable to run `test_browser.py` due to some weird Import module error on modules that are installed, so I'm kind of Pull Requesting blindly. Does it matter that I say I'm confident in the changes though ?