### PR TITLE
debug _find_link_internal and remove xfail on related test

### DIFF
--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -292,7 +292,7 @@ class StatefulBrowser(Browser):
             raise ValueError('link parameter cannot be treated as '
                              'url_regex because url_regex is already '
                              'present in keyword arguments')
-        else:
+        elif link:
             kwargs['url_regex'] = link
 
         try:

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -424,8 +424,7 @@ def test_referer_submit_headers(httpbin):
 @pytest.mark.parametrize('expected, kwargs', [
     pytest.param('/foo', {}, id='none'),
     pytest.param('/get', {'text': 'Link'}, id='text'),
-    pytest.param('/get', {'url_regex': 'get'}, id='regex',
-                 marks=pytest.mark.xfail),
+    pytest.param('/get', {'url_regex': 'get'}, id='regex'),
 ])
 def test_follow_link_arg(httpbin, expected, kwargs):
     browser = mechanicalsoup.StatefulBrowser()


### PR DESCRIPTION
If you called the function with url_regex='/something' and not the
link argument, it would set the url_regex to None, and thus the result
would be not the one expected.

This is tested by the test fixed by #261.

(Followup on #256)
