### PR TITLE
Enhancement for dates in the documentation pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+from datetime import datetime
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -48,7 +49,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'MechanicalSoup'
-copyright = '2014'
+copyright = '2014-{}'.format(datetime.utcnow().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_theme = 'default'
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
* Automatically update the copyright date
* Add the "last updated" date

Locally, these changes will look like this:
![image](https://user-images.githubusercontent.com/846186/54856282-e74f3f00-4cb6-11e9-91de-527d6fff4d0d.png)
