### PR TITLE
Officially support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Validate all YAML changes, e.g. http://lint.travis-ci.org/
 
 sudo: false
+dist: xenial
 language: python
 cache: pip
 python:
@@ -8,8 +9,9 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy
-  - pypy3.5
+  - 3.7
+  - pypy2.7-6.0
+  - pypy3.5-6.0
 install:
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
   - pip install pytest-cov       # needed for the codecov uploader

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     packages=['mechanicalsoup'],


### PR DESCRIPTION
Add tests against python 3.7 in .travis.yml.

Note that we can no longer use the default dist, "trusty", because
python 3.7 requires an SSL package that is only available as of
xenial. See https://github.com/travis-ci/travis-ci/issues/9815.

On xenial, the PyPy packages have a different naming convention
(e.g. just `pypy` and `pypy2.7` don't exist), so we switch to the
naming convention for the most recent v6.0 PyPy release.
See https://travis-ci.community/t/pypy-2-7-on-xenial/889.