### PR TITLE
Add "enctype respecting" feature and tests

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -339,8 +339,10 @@ def test_upload_file(httpbin):
                     ("first file content", "second file content"))
 
     # The form doesn't have a type=file field, but the target action
-    # does show it => add the fields ourselves.
+    # does show it => add the fields ourselves, and add enctype too.
     browser.select_form()
+    browser._StatefulBrowser__state.form.form[
+      "enctype"] = "multipart/form-data"
     browser.new_control("file", "first", path1)
     browser.new_control("file", "second", "")
     browser["second"] = path2


### PR DESCRIPTION
Fixes #242.

Make MechanicalSoup behave as a real browser:

- only "multipart/form-data" enctype allow file sending

- forms without file inputs can now be sent as "multipart/form-data"
  if specified.

- "application/x-www-form-urlencoded" is the default when enctype is wrong
  or not specified

The added code uses a hack because of a lack in Requests
functionalities: Requests doesn't support forcing enctype yet, and
doesn't allow to submit using "multipart/data-form" enctype without
submitting files. So the best way we found to bypass this is to pass
an modified dict as files to Requests. This code could change in the
future if Requests implements a "force enctype" feature.