### PR TITLE
Drop support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 cache: pip
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Python 3.4 has reached its end of life on March 18, 2019.

See https://www.python.org/dev/peps/pep-0429/.

More practically, lxml-4.4.0 requires python 3.5+, which causes our
CI for python 3.4 to fail.