### PR TITLE
Properties

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -8,6 +8,18 @@ Version 1.0 (in development)
 Main changes:
 -------------
 
+* ``StatefulBrowser`` methods ``get_current_page``,
+  ``get_current_form`` and ``get_url`` have been deprecated in favor
+  of ``page``, ``form`` and ``url`` properties (e.g. the new
+  ``x.page`` is equivalent to the now deprecated
+  ``x.get_current_page()``) [`#175
+  <https://github.com/MechanicalSoup/MechanicalSoup/issues/175`__]
+
+* ``StatefulBrowser.form`` will raise an ``AttributeError`` instead of
+  returning ``None`` if no form has been selected yet. Note that
+  ``StatefulBrowser.get_current_form()`` still returns ``None`` for
+  backward compatibility.
+
 * Added ability to submit a form without updating `StatefulBrowser` internal
   state. This means you get a response from the form submission, but your
   browser "stays" on the same page. Useful for handling forms that result in

--- a/examples/example.py
+++ b/examples/example.py
@@ -30,7 +30,7 @@ resp = browser.submit_selected()
 # browser.launch_browser()
 
 # verify we are now logged in
-page = browser.get_current_page()
+page = browser.page
 messages = page.find("div", class_="flash-messages")
 if messages:
     print(messages.text)

--- a/examples/expl_duck_duck_go.py
+++ b/examples/expl_duck_duck_go.py
@@ -1,5 +1,9 @@
-"""Example usage of MechanicalSoup to get the results from
-DuckDuckGo."""
+"""WARNING: this script does not seem to work with the current
+DuckDuckGo version (as of 2019/08).
+
+Example usage of MechanicalSoup to get the results from
+DuckDuckGo.
+"""
 
 import mechanicalsoup
 
@@ -13,5 +17,5 @@ browser["q"] = "MechanicalSoup"
 browser.submit_selected()
 
 # Display the results
-for link in browser.get_current_page().select('a.result__a'):
+for link in browser.page.select('a.result__a'):
     print(link.text, '->', link.attrs['href'])

--- a/examples/expl_httpbin.py
+++ b/examples/expl_httpbin.py
@@ -3,10 +3,10 @@ import mechanicalsoup
 browser = mechanicalsoup.StatefulBrowser()
 browser.open("http://httpbin.org/")
 
-print(browser.get_url())
+print(browser.url)
 browser.follow_link("forms")
-print(browser.get_url())
-print(browser.get_current_page())
+print(browser.url)
+print(browser.page)
 
 browser.select_form('form[action="/post"]')
 browser["custname"] = "Me"
@@ -21,7 +21,7 @@ browser["comments"] = "This pizza looks really good :-)"
 # browser.launch_browser()
 
 # Uncomment to display a summary of the filled-in form
-# browser.get_current_form().print_summary()
+# browser.form.print_summary()
 
 response = browser.submit_selected()
 print(response.text)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -60,6 +60,12 @@ class StatefulBrowser(Browser):
         self.__verbose = 0
         self.__state = _BrowserState()
 
+        # Aliases for backwards compatibility
+        # (Included specifically in __init__ to suppress them in Sphinx docs)
+        self.get_current_page = lambda: self.page
+        self.get_current_form = lambda: self.form
+        self.get_url = lambda: self.url
+
     def set_debug(self, debug):
         """Set the debug mode (off by default).
 
@@ -86,11 +92,18 @@ class StatefulBrowser(Browser):
         """Get the verbosity level. See :func:`set_verbose()`."""
         return self.__verbose
 
-    def get_url(self):
+    @property
+    def page(self):
+        """Get the current page as a soup object."""
+        return self.__state.page
+
+    @property
+    def url(self):
         """Get the URL of the currently visited page."""
         return self.__state.url
 
-    def get_current_form(self):
+    @property
+    def form(self):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
@@ -105,10 +118,6 @@ class StatefulBrowser(Browser):
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
         return self.get_current_form().new_control(type, name, value, **kwargs)
-
-    def get_current_page(self):
-        """Get the current page as a soup object."""
-        return self.__state.page
 
     def absolute_url(self, url):
         """Return the absolute URL made from the current URL and ``url``.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -63,7 +63,9 @@ class StatefulBrowser(Browser):
         # Aliases for backwards compatibility
         # (Included specifically in __init__ to suppress them in Sphinx docs)
         self.get_current_page = lambda: self.page
-        self.get_current_form = lambda: self.form
+        # Almost same as self.form, but don't raise an error if no
+        # form was selected for backward compatibility.
+        self.get_current_form = lambda: self.__state.form
         self.get_url = lambda: self.url
 
     def set_debug(self, debug):
@@ -107,6 +109,8 @@ class StatefulBrowser(Browser):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
+        if self.__state.form is None:
+            raise AttributeError("No form has been selected yet on this page.")
         return self.__state.form
 
     def __setitem__(self, name, value):

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -117,11 +117,11 @@ class StatefulBrowser(Browser):
         """Call item assignment on the currently selected form.
         See :func:`Form.__setitem__`.
         """
-        self.get_current_form()[name] = value
+        self.form[name] = value
 
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
-        return self.get_current_form().new_control(type, name, value, **kwargs)
+        return self.form.new_control(type, name, value, **kwargs)
 
     def absolute_url(self, url):
         """Return the absolute URL made from the current URL and ``url``.
@@ -129,7 +129,7 @@ class StatefulBrowser(Browser):
         ``url``, as in the `.urljoin() method of urllib.parse
         <https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin>`__.
         """
-        return urllib.parse.urljoin(self.get_url(), url)
+        return urllib.parse.urljoin(self.url, url)
 
     def open(self, url, *args, **kwargs):
         """Open the URL and store the Browser's state in this object.
@@ -211,8 +211,8 @@ class StatefulBrowser(Browser):
             self.__state.form = Form(selector)
         else:
             # nr is a 0-based index for consistency with mechanize
-            found_forms = self.get_current_page().select(selector,
-                                                         limit=nr + 1)
+            found_forms = self.page.select(selector,
+                                           limit=nr + 1)
             if len(found_forms) != nr + 1:
                 if self.__debug:
                     print('select_form failed for', selector)
@@ -220,7 +220,7 @@ class StatefulBrowser(Browser):
                 raise LinkNotFoundError()
             self.__state.form = Form(found_forms[-1])
 
-        return self.get_current_form()
+        return self.form
 
     def submit_selected(self, btnName=None, update_state=True,
                         *args, **kwargs):
@@ -235,9 +235,9 @@ class StatefulBrowser(Browser):
         a download of a file. All other arguments are forwarded to
         :func:`Browser.submit`.
         """
-        self.get_current_form().choose_submit(btnName)
+        self.form.choose_submit(btnName)
 
-        referer = self.get_url()
+        referer = self.url
         if referer is not None:
             if 'headers' in kwargs:
                 kwargs['headers']['Referer'] = referer
@@ -268,7 +268,7 @@ class StatefulBrowser(Browser):
         the `.find_all() method in BeautifulSoup
         <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all>`__.
         """
-        all_links = self.get_current_page().find_all(
+        all_links = self.page.find_all(
             'a', href=True, *args, **kwargs)
         if url_regex is not None:
             all_links = [a for a in all_links
@@ -340,7 +340,7 @@ class StatefulBrowser(Browser):
         """
         link = self._find_link_internal(link, args, kwargs)
 
-        referer = self.get_url()
+        referer = self.url
         headers = {'Referer': referer} if referer else None
 
         return self.open_relative(link['href'], headers=headers)
@@ -364,7 +364,7 @@ class StatefulBrowser(Browser):
         link = self._find_link_internal(link, args, kwargs)
         url = self.absolute_url(link['href'])
 
-        referer = self.get_url()
+        referer = self.url
         headers = {'Referer': referer} if referer else None
 
         response = self.session.get(url, headers=headers)
@@ -385,5 +385,5 @@ class StatefulBrowser(Browser):
             Defaults to the current page of the ``StatefulBrowser`` instance.
         """
         if soup is None:
-            soup = self.get_current_page()
+            soup = self.page
         super(StatefulBrowser, self).launch_browser(soup)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -200,7 +200,7 @@ def test_form_noaction():
     form = browser.select_form('#choose-submit-form')
     form['text1'] = 'newText1'
     res = browser.submit_selected()
-    assert res.status_code == 200 and browser.get_url() == url
+    assert res.status_code == 200 and browser.url == url
 
 
 submit_form_action = '''
@@ -224,7 +224,7 @@ def test_form_action():
     form = browser.select_form('#choose-submit-form')
     form['text1'] = 'newText1'
     res = browser.submit_selected()
-    assert res.status_code == 200 and browser.get_url() == url
+    assert res.status_code == 200 and browser.url == url
 
 
 set_select_form = '''
@@ -320,7 +320,7 @@ def test_form_set_radio_checkbox(capsys):
     form = browser.select_form("form")
     form.set_radio({"size": "small"})
     form.set_checkbox({"topping": "cheese"})
-    browser.get_current_form().print_summary()
+    browser.form.print_summary()
     out, err = capsys.readouterr()
     # Different versions of bs4 show either <input></input> or
     # <input/>. Normalize before comparing.
@@ -405,7 +405,7 @@ def test_form_print_summary(capsys):
     browser.open_fake_page(page_with_various_fields,
                            url="http://example.com/invalid/")
     browser.select_form("form")
-    browser.get_current_form().print_summary()
+    browser.form.print_summary()
     out, err = capsys.readouterr()
     # Different versions of bs4 show either <input></input> or
     # <input/>. Normalize before comparing.

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -23,6 +23,19 @@ def test_request_forward():
     assert r.text == 'Success!'
 
 
+def test_properties():
+    """Check that properties return the same value as the getter."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>', url="http://example.com")
+    assert browser.page == browser.get_current_page()
+    assert browser.page is not None
+    assert browser.url == browser.get_url()
+    assert browser.url is not None
+    browser.select_form()
+    assert browser.form == browser.get_current_form()
+    assert browser.form is not None
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -36,6 +36,14 @@ def test_properties():
     assert browser.form is not None
 
 
+def test_get_selected_form_unselected():
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>')
+    with pytest.raises(AttributeError, match="No form has been selected yet."):
+        browser.form
+    assert browser.get_current_form() is None
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -54,7 +54,7 @@ def test_submit_online(httpbin):
             browser.follow_link(link)
             break
     browser.follow_link("forms/post")
-    assert browser.get_url() == httpbin + "/forms/post"
+    assert browser.url == httpbin + "/forms/post"
     browser.select_form("form")
     browser["custname"] = "Customer Name Here"
     browser["size"] = "medium"
@@ -62,7 +62,7 @@ def test_submit_online(httpbin):
     # Change our mind to make sure old boxes are unticked
     browser["topping"] = ("cheese", "onion")
     browser["comments"] = "Some comment here"
-    browser.get_current_form().set("nosuchfield", "new value", True)
+    browser.form.set("nosuchfield", "new value", True)
     response = browser.submit_selected()
     json = response.json()
     data = json["form"]
@@ -108,11 +108,11 @@ def test_open_relative(httpbin):
     # Open a relative page and make sure remote host and browser agree on URL
     resp = browser.open_relative("/get")
     assert resp.json()['url'] == httpbin + "/get"
-    assert browser.get_url() == httpbin + "/get"
+    assert browser.url == httpbin + "/get"
 
     # Test passing additional kwargs to the session
     resp = browser.open_relative("/basic-auth/me/123", auth=('me', '123'))
-    assert browser.get_url() == httpbin + "/basic-auth/me/123"
+    assert browser.url == httpbin + "/basic-auth/me/123"
     assert resp.json() == {"authenticated": True, "user": "me"}
 
 
@@ -264,7 +264,7 @@ def test_new_control(httpbin):
     browser.new_control("textarea", "size", "Sooo big !")
     browser.new_control("text", "comments", "This is an override comment")
     browser.new_control("checkbox", "foo", "valval", checked="checked")
-    tag = browser.get_current_form().form.find("input", {"name": "foo"})
+    tag = browser.form.form.find("input", {"name": "foo"})
     assert tag.attrs["checked"] == "checked"
     browser["temperature"] = "hot"
     response = browser.submit_selected()
@@ -367,7 +367,7 @@ def test_upload_file(httpbin):
     browser.new_control("file", "first", path1)
     browser.new_control("file", "second", "")
     browser["second"] = path2
-    browser.get_current_form().print_summary()
+    browser.form.print_summary()
     response = browser.submit_selected()
     files = response.json()["files"]
     assert files["first"] == "first file content"
@@ -411,7 +411,7 @@ def test_select_form_tag_object():
 def test_referer_follow_link(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
     open_legacy_httpbin(browser, httpbin)
-    start_url = browser.get_url()
+    start_url = browser.url
     response = browser.follow_link("/headers")
     referer = response.json()["headers"]["Referer"]
     actual_ref = re.sub('/*$', '', referer)
@@ -470,7 +470,7 @@ def test_follow_link_arg(httpbin, expected, kwargs):
     html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
     browser.open_fake_page(html, httpbin.url)
     browser.follow_link(**kwargs)
-    assert browser.get_url() == httpbin + expected
+    assert browser.url == httpbin + expected
 
 
 def test_link_arg_multiregex(httpbin):
@@ -491,13 +491,13 @@ def test_download_link(httpbin):
     open_legacy_httpbin(browser, httpbin)
     tmpdir = tempfile.mkdtemp()
     tmpfile = tmpdir + '/nosuchfile.png'
-    current_url = browser.get_url()
-    current_page = browser.get_current_page()
+    current_url = browser.url
+    current_page = browser.page
     response = browser.download_link(file=tmpfile, link='image/png')
 
     # Check that the browser state has not changed
-    assert browser.get_url() == current_url
-    assert browser.get_current_page() == current_page
+    assert browser.url == current_url
+    assert browser.page == current_page
 
     # Check that the file was downloaded
     assert os.path.isfile(tmpfile)
@@ -510,13 +510,13 @@ def test_download_link_nofile(httpbin):
     """Test downloading the contents of a link without saving it."""
     browser = mechanicalsoup.StatefulBrowser()
     open_legacy_httpbin(browser, httpbin)
-    current_url = browser.get_url()
-    current_page = browser.get_current_page()
+    current_url = browser.url
+    current_page = browser.page
     response = browser.download_link(link='image/png')
 
     # Check that the browser state has not changed
-    assert browser.get_url() == current_url
-    assert browser.get_current_page() == current_page
+    assert browser.url == current_url
+    assert browser.page == current_page
 
     # Check that we actually downloaded a PNG file
     assert response.content[:4] == b'\x89PNG'
@@ -530,13 +530,13 @@ def test_download_link_to_existing_file(httpbin):
     tmpfile = tmpdir + '/existing.png'
     with open(tmpfile, "w") as f:
         f.write("initial content")
-    current_url = browser.get_url()
-    current_page = browser.get_current_page()
+    current_url = browser.url
+    current_page = browser.page
     response = browser.download_link('image/png', tmpfile)
 
     # Check that the browser state has not changed
-    assert browser.get_url() == current_url
-    assert browser.get_current_page() == current_page
+    assert browser.url == current_url
+    assert browser.page == current_page
 
     # Check that the file was downloaded
     assert os.path.isfile(tmpfile)
@@ -552,14 +552,14 @@ def test_download_link_404(httpbin):
                            url=httpbin.url)
     tmpdir = tempfile.mkdtemp()
     tmpfile = tmpdir + '/nosuchfile.txt'
-    current_url = browser.get_url()
-    current_page = browser.get_current_page()
+    current_url = browser.url
+    current_page = browser.page
     with pytest.raises(mechanicalsoup.LinkNotFoundError):
         browser.download_link(file=tmpfile, link_text='Link')
 
     # Check that the browser state has not changed
-    assert browser.get_url() == current_url
-    assert browser.get_current_page() == current_page
+    assert browser.url == current_url
+    assert browser.page == current_page
 
     # Check that the file was not downloaded
     assert not os.path.exists(tmpfile)
@@ -572,13 +572,13 @@ def test_download_link_referer(httpbin):
     browser.open_fake_page('<a href="/headers">Link</a>',
                            url=ref)
     tmpfile = tempfile.NamedTemporaryFile()
-    current_url = browser.get_url()
-    current_page = browser.get_current_page()
+    current_url = browser.url
+    current_page = browser.page
     browser.download_link(file=tmpfile.name, link_text='Link')
 
     # Check that the browser state has not changed
-    assert browser.get_url() == current_url
-    assert browser.get_current_page() == current_page
+    assert browser.url == current_url
+    assert browser.page == current_page
 
     # Check that the file was downloaded
     with open(tmpfile.name) as f:
@@ -600,8 +600,8 @@ def test_refresh_open():
 
     browser.refresh()
 
-    assert browser.get_url() == url
-    assert browser.get_current_page() == reload_page
+    assert browser.url == url
+    assert browser.page == reload_page
 
 
 def test_refresh_follow_link():
@@ -622,8 +622,8 @@ def test_refresh_follow_link():
 
     browser.refresh()
 
-    assert browser.get_url() == follow_url
-    assert browser.get_current_page() == reload_page
+    assert browser.url == follow_url
+    assert browser.page == reload_page
 
 
 def test_refresh_form_not_retained():
@@ -641,9 +641,10 @@ def test_refresh_form_not_retained():
 
     browser.refresh()
 
-    assert browser.get_url() == url
-    assert browser.get_current_page() == reload_page
-    assert browser.get_current_form() is None
+    assert browser.url == url
+    assert browser.page == reload_page
+    with pytest.raises(AttributeError, match="No form has been selected yet."):
+        browser.form
 
 
 def test_refresh_error():


### PR DESCRIPTION
This superseeds #185 (which I'm keeping untouched for the record).

Essentially:

* No more getters in the recommended interface, just properties.

* Getters are kept with their old names, only for backward compatibility

* Properties are now used everywhere (examples, code, tests)

Each commit passes tests. PR best reviewed commit-by-commit, as it contains both small manual changes with batch search-and-replace.