### PR TITLE
Properties

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -11,6 +11,23 @@ Version 0.12
 Main changes:
 -------------
 
+* ``StatefulBrowser`` methods ``get_current_page``,
+  ``get_current_form`` and ``get_url`` have been deprecated in favor
+  of ``page``, ``form`` and ``url`` properties (e.g. the new
+  ``x.page`` is equivalent to the now deprecated
+  ``x.get_current_page()``) [`#175
+  <https://github.com/MechanicalSoup/MechanicalSoup/issues/175`__]
+
+* ``StatefulBrowser.form`` will raise an ``AttributeError`` instead of
+  returning ``None`` if no form has been selected yet. Note that
+  ``StatefulBrowser.get_current_form()`` still returns ``None`` for
+  backward compatibility.
+
+* Added ability to submit a form without updating `StatefulBrowser` internal
+  state. This means you get a response from the form submission, but your
+  browser "stays" on the same page. Useful for handling forms that result in
+  a download of a file or opening a new window.
+
 * Changes in official python version support: added 3.7 and dropped 3.4.
 
 * Added ability to submit a form without updating ``StatefulBrowser`` internal

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -145,7 +145,7 @@ unique ``id="button3"`` attribute, you can do the following::
 
     br = mechanicalsoup.StatefulBrowser()
     br.open(...)
-    submit = br.get_current_page().find('input', id='button3')
+    submit = br.page.find('input', id='button3')
     form = br.select_form()
     form.choose_submit(submit)
     br.submit_selected()

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -32,14 +32,14 @@ contains the content of the page we just downloaded.
 Just like a normal browser's URL bar, the browser remembers which URL
 it's browsing::
 
-  >>> browser.get_url()
+  >>> browser.url
   'http://httpbin.org/'
 
 Now, let's follow the link to ``/forms/post``::
 
   >>> browser.follow_link("forms")
   <Response [200]>
-  >>> browser.get_url()
+  >>> browser.url
   'http://httpbin.org/forms/post'
 
 We passed a regular expression ``"forms"``
@@ -51,7 +51,7 @@ get back to it.
 We're now visiting http://httpbin.org/forms/post, which contains a
 form. Let's see the page content::
 
-  >>> browser.get_current_page()
+  >>> browser.page
   <!DOCTYPE html>
   <html>
   ...
@@ -59,13 +59,13 @@ form. Let's see the page content::
   ...
 
 Actually, the return type
-of :func:`~mechanicalsoup.StatefulBrowser().get_current_page` is
+of :func:`~mechanicalsoup.StatefulBrowser().page` is
 bs4.BeautifulSoup_. BeautifulSoup, aka bs4, is the second library used
 by Mechanicalsoup: it is an HTML manipulation library. You can now
 navigate in the tags of the pages using BeautifulSoup. For example, to
 get all the ``<legend>`` tags::
 
-  >>> browser.get_current_page().find_all('legend')
+  >>> browser.page.find_all('legend')
   [<legend> Pizza Size </legend>, <legend> Pizza Toppings </legend>]
 
 To fill-in a form, we need to tell MechanicalSoup which form we're
@@ -83,7 +83,7 @@ Now, give a value to fields in the form. First, what are the available
 fields? You can print a summary of the currently selected form
 with :func:`~mechanicalsoup.Form.print_summary()`::
 
-  >>> browser.get_current_form().print_summary()
+  >>> browser.form.print_summary()
   <input name="custname"/>
   <input name="custtel" type="tel"/>
   <input name="custemail" type="email"/>
@@ -149,7 +149,7 @@ It's also possible to check the content
 with :func:`~mechanicalsoup.Form.print_summary()` (that we already
 used to list the fields)::
 
-  >>> browser.get_current_form().print_summary()
+  >>> browser.form.print_summary()
   <input name="custname" value="Me"/>
   <input name="custtel" type="tel" value="00 00 0001"/>
   <input name="custemail" type="email" value="nobody@example.com"/>

--- a/examples/example.py
+++ b/examples/example.py
@@ -30,7 +30,7 @@ resp = browser.submit_selected()
 # browser.launch_browser()
 
 # verify we are now logged in
-page = browser.get_current_page()
+page = browser.page
 messages = page.find("div", class_="flash-messages")
 if messages:
     print(messages.text)

--- a/examples/expl_duck_duck_go.py
+++ b/examples/expl_duck_duck_go.py
@@ -1,5 +1,9 @@
-"""Example usage of MechanicalSoup to get the results from
-DuckDuckGo."""
+"""WARNING: this script does not seem to work with the current
+DuckDuckGo version (as of 2019/08).
+
+Example usage of MechanicalSoup to get the results from
+DuckDuckGo.
+"""
 
 import mechanicalsoup
 
@@ -13,5 +17,5 @@ browser["q"] = "MechanicalSoup"
 browser.submit_selected()
 
 # Display the results
-for link in browser.get_current_page().select('a.result__a'):
+for link in browser.page.select('a.result__a'):
     print(link.text, '->', link.attrs['href'])

--- a/examples/expl_httpbin.py
+++ b/examples/expl_httpbin.py
@@ -3,10 +3,10 @@ import mechanicalsoup
 browser = mechanicalsoup.StatefulBrowser()
 browser.open("http://httpbin.org/")
 
-print(browser.get_url())
+print(browser.url)
 browser.follow_link("forms")
-print(browser.get_url())
-print(browser.get_current_page())
+print(browser.url)
+print(browser.page)
 
 browser.select_form('form[action="/post"]')
 browser["custname"] = "Me"
@@ -21,7 +21,7 @@ browser["comments"] = "This pizza looks really good :-)"
 # browser.launch_browser()
 
 # Uncomment to display a summary of the filled-in form
-# browser.get_current_form().print_summary()
+# browser.form.print_summary()
 
 response = browser.submit_selected()
 print(response.text)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -60,6 +60,12 @@ class StatefulBrowser(Browser):
         self.__verbose = 0
         self.__state = _BrowserState()
 
+        # Aliases for backwards compatibility
+        # (Included specifically in __init__ to suppress them in Sphinx docs)
+        self.get_current_page = lambda: self.page
+        self.get_current_form = lambda: self.form
+        self.get_url = lambda: self.url
+
     def set_debug(self, debug):
         """Set the debug mode (off by default).
 
@@ -86,11 +92,18 @@ class StatefulBrowser(Browser):
         """Get the verbosity level. See :func:`set_verbose()`."""
         return self.__verbose
 
-    def get_url(self):
+    @property
+    def page(self):
+        """Get the current page as a soup object."""
+        return self.__state.page
+
+    @property
+    def url(self):
         """Get the URL of the currently visited page."""
         return self.__state.url
 
-    def get_current_form(self):
+    @property
+    def form(self):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
@@ -105,10 +118,6 @@ class StatefulBrowser(Browser):
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
         return self.get_current_form().new_control(type, name, value, **kwargs)
-
-    def get_current_page(self):
-        """Get the current page as a soup object."""
-        return self.__state.page
 
     def absolute_url(self, url):
         """Return the absolute URL made from the current URL and ``url``.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -63,7 +63,9 @@ class StatefulBrowser(Browser):
         # Aliases for backwards compatibility
         # (Included specifically in __init__ to suppress them in Sphinx docs)
         self.get_current_page = lambda: self.page
-        self.get_current_form = lambda: self.form
+        # Almost same as self.form, but don't raise an error if no
+        # form was selected for backward compatibility.
+        self.get_current_form = lambda: self.__state.form
         self.get_url = lambda: self.url
 
     def set_debug(self, debug):
@@ -107,6 +109,8 @@ class StatefulBrowser(Browser):
         """Get the currently selected form as a :class:`Form` object.
         See :func:`select_form`.
         """
+        if self.__state.form is None:
+            raise AttributeError("No form has been selected yet on this page.")
         return self.__state.form
 
     def __setitem__(self, name, value):

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -117,11 +117,11 @@ class StatefulBrowser(Browser):
         """Call item assignment on the currently selected form.
         See :func:`Form.__setitem__`.
         """
-        self.get_current_form()[name] = value
+        self.form[name] = value
 
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
-        return self.get_current_form().new_control(type, name, value, **kwargs)
+        return self.form.new_control(type, name, value, **kwargs)
 
     def absolute_url(self, url):
         """Return the absolute URL made from the current URL and ``url``.
@@ -129,7 +129,7 @@ class StatefulBrowser(Browser):
         ``url``, as in the `.urljoin() method of urllib.parse
         <https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin>`__.
         """
-        return urllib.parse.urljoin(self.get_url(), url)
+        return urllib.parse.urljoin(self.url, url)
 
     def open(self, url, *args, **kwargs):
         """Open the URL and store the Browser's state in this object.
@@ -211,8 +211,8 @@ class StatefulBrowser(Browser):
             self.__state.form = Form(selector)
         else:
             # nr is a 0-based index for consistency with mechanize
-            found_forms = self.get_current_page().select(selector,
-                                                         limit=nr + 1)
+            found_forms = self.page.select(selector,
+                                           limit=nr + 1)
             if len(found_forms) != nr + 1:
                 if self.__debug:
                     print('select_form failed for', selector)
@@ -220,7 +220,7 @@ class StatefulBrowser(Browser):
                 raise LinkNotFoundError()
             self.__state.form = Form(found_forms[-1])
 
-        return self.get_current_form()
+        return self.form
 
     def submit_selected(self, btnName=None, update_state=True,
                         *args, **kwargs):
@@ -235,9 +235,9 @@ class StatefulBrowser(Browser):
         a download of a file. All other arguments are forwarded to
         :func:`Browser.submit`.
         """
-        self.get_current_form().choose_submit(btnName)
+        self.form.choose_submit(btnName)
 
-        referer = self.get_url()
+        referer = self.url
         if referer is not None:
             if 'headers' in kwargs:
                 kwargs['headers']['Referer'] = referer
@@ -268,7 +268,7 @@ class StatefulBrowser(Browser):
         the `.find_all() method in BeautifulSoup
         <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all>`__.
         """
-        all_links = self.get_current_page().find_all(
+        all_links = self.page.find_all(
             'a', href=True, *args, **kwargs)
         if url_regex is not None:
             all_links = [a for a in all_links
@@ -340,7 +340,7 @@ class StatefulBrowser(Browser):
         """
         link = self._find_link_internal(link, args, kwargs)
 
-        referer = self.get_url()
+        referer = self.url
         headers = {'Referer': referer} if referer else None
 
         return self.open_relative(link['href'], headers=headers)
@@ -364,7 +364,7 @@ class StatefulBrowser(Browser):
         link = self._find_link_internal(link, args, kwargs)
         url = self.absolute_url(link['href'])
 
-        referer = self.get_url()
+        referer = self.url
         headers = {'Referer': referer} if referer else None
 
         response = self.session.get(url, headers=headers)
@@ -385,5 +385,5 @@ class StatefulBrowser(Browser):
             Defaults to the current page of the ``StatefulBrowser`` instance.
         """
         if soup is None:
-            soup = self.get_current_page()
+            soup = self.page
         super(StatefulBrowser, self).launch_browser(soup)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -200,7 +200,7 @@ def test_form_noaction():
     form = browser.select_form('#choose-submit-form')
     form['text1'] = 'newText1'
     res = browser.submit_selected()
-    assert res.status_code == 200 and browser.get_url() == url
+    assert res.status_code == 200 and browser.url == url
 
 
 submit_form_action = '''
@@ -224,7 +224,7 @@ def test_form_action():
     form = browser.select_form('#choose-submit-form')
     form['text1'] = 'newText1'
     res = browser.submit_selected()
-    assert res.status_code == 200 and browser.get_url() == url
+    assert res.status_code == 200 and browser.url == url
 
 
 set_select_form = '''
@@ -320,7 +320,7 @@ def test_form_set_radio_checkbox(capsys):
     form = browser.select_form("form")
     form.set_radio({"size": "small"})
     form.set_checkbox({"topping": "cheese"})
-    browser.get_current_form().print_summary()
+    browser.form.print_summary()
     out, err = capsys.readouterr()
     # Different versions of bs4 show either <input></input> or
     # <input/>. Normalize before comparing.
@@ -405,7 +405,7 @@ def test_form_print_summary(capsys):
     browser.open_fake_page(page_with_various_fields,
                            url="http://example.com/invalid/")
     browser.select_form("form")
-    browser.get_current_form().print_summary()
+    browser.form.print_summary()
     out, err = capsys.readouterr()
     # Different versions of bs4 show either <input></input> or
     # <input/>. Normalize before comparing.

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -23,6 +23,19 @@ def test_request_forward():
     assert r.text == 'Success!'
 
 
+def test_properties():
+    """Check that properties return the same value as the getter."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>', url="http://example.com")
+    assert browser.page == browser.get_current_page()
+    assert browser.page is not None
+    assert browser.url == browser.get_url()
+    assert browser.url is not None
+    browser.select_form()
+    assert browser.form == browser.get_current_form()
+    assert browser.form is not None
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -36,6 +36,14 @@ def test_properties():
     assert browser.form is not None
 
 
+def test_get_selected_form_unselected():
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>')
+    with pytest.raises(AttributeError, match="No form has been selected yet."):
+        browser.form
+    assert browser.get_current_form() is None
+
+
 def test_submit_online(httpbin):
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
     browser = mechanicalsoup.StatefulBrowser()


### PR DESCRIPTION
This superseeds #185 (which I'm keeping untouched for the record), and #293 (which I closed by mistake, messing up with a `git push` command, sorry).

Essentially:

* No more getters in the recommended interface, just properties.

* Getters are kept with their old names, only for backward compatibility

* Properties are now used everywhere (examples, code, tests)

Each commit passes tests. PR best reviewed commit-by-commit, as it contains both small manual changes with batch search-and-replace.