### PR TITLE
Parse response only when Content-Type is not set

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -65,8 +65,9 @@ class Browser(object):
     @staticmethod
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
-        if ("text/html" in response.headers.get("Content-Type", "") or
-                Browser.__looks_like_html(response)):
+        content_type = response.headers.get("Content-Type", "")
+        if ("text/html" in content_type or (not content_type and 
+                Browser.__looks_like_html(response))):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -66,8 +66,8 @@ class Browser(object):
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
         content_type = response.headers.get("Content-Type", "")
-        if ("text/html" in content_type or (not content_type and
-                Browser.__looks_like_html(response))):
+        if ("text/html" in content_type or
+            (not content_type and Browser.__looks_like_html(response))):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -66,7 +66,7 @@ class Browser(object):
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
         content_type = response.headers.get("Content-Type", "")
-        if ("text/html" in content_type or (not content_type and 
+        if ("text/html" in content_type or (not content_type and
                 Browser.__looks_like_html(response))):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -66,8 +66,8 @@ class Browser(object):
     def add_soup(response, soup_config):
         """Attaches a soup object to a requests response."""
         content_type = response.headers.get("Content-Type", "")
-        if ("text/html" in content_type or
-            (not content_type and Browser.__looks_like_html(response))):
+        if ("text/html" in content_type or (not content_type and
+                                            Browser.__looks_like_html(response))):
             response.soup = bs4.BeautifulSoup(response.content, **soup_config)
         else:
             response.soup = None


### PR DESCRIPTION
Current implementation parses response.text both when content-type is not text/html or empty
This leads parsing data when content-type is binary data such as application/x-gzip.
Parse only when content-type not passed.