### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
 
     license=about['__license__'],
 
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+
     classifiers=[
         'License :: OSI Approved :: MIT License',
 


### PR DESCRIPTION
If there's one last release before dropping Python 2 (https://github.com/MechanicalSoup/MechanicalSoup/issues/310), this will help pip install the right version of MechanicalSoup for their running Python, and ease migration.