### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - pypy
   - pypy3
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,21 +52,11 @@ You can develop against multiple versions of Python using
     python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
     pip install -r requirements.txt -r tests/requirements.txt
 
-and
-
-::
-
-    virtualenv -p python2 --no-site-packages .virtual-py2 && source .virtual-py2/bin/activate
-    pip install -r requirements.txt -r tests/requirements.txt
-
 After making changes, run pytest in all virtualenvs:
 
 ::
 
     source .virtual-py3/bin/activate
-    pytest
-
-    source .virtual-py2/bin/activate
     pytest
 
 Installation should be as simple as:

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Installation
 
 |Latest Version| |Supported Versions|
 
-PyPy and PyPy3 are also supported (and tested against).
+PyPy3 is also supported (and tested against).
 
 Download and install the latest released version from `PyPI <https://pypi.python.org/pypi/MechanicalSoup/>`__::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # MechanicalSoup documentation build configuration file, created by
 # sphinx-quickstart on Sun Sep 14 18:44:39 2014.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -3,7 +3,7 @@ Introduction
 
 |Latest Version| |Supported Versions|
 
-PyPy and PyPy3 are also supported (and tested against).
+PyPy3 is also supported (and tested against).
 
 Find MechanicalSoup on `Python Package Index (Pypi)
 <https://pypi.python.org/pypi/MechanicalSoup/>`__ and follow the

--- a/examples/example.py
+++ b/examples/example.py
@@ -2,7 +2,6 @@
 
 NOTE: This example will not work if the user has 2FA enabled."""
 
-from __future__ import print_function
 import argparse
 import mechanicalsoup
 from getpass import getpass

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -10,7 +10,7 @@ from .__version__ import __version__, __title__
 import weakref
 
 
-class Browser(object):
+class Browser:
     """Builds a low-level Browser.
 
     It is recommended to use :class:`StatefulBrowser` for most applications,
@@ -91,7 +91,9 @@ class Browser(object):
         # set a default user_agent if not specified
         if user_agent is None:
             requests_ua = requests.utils.default_user_agent()
-            user_agent = '%s (%s/%s)' % (requests_ua, __title__, __version__)
+            user_agent = '{} ({}/{})'.format(
+                requests_ua, __title__, __version__
+            )
 
         # the requests module uses a case-insensitive dict for session headers
         self.session.headers['User-agent'] = user_agent
@@ -194,7 +196,7 @@ class Browser(object):
                 # the form as a text input and the file is not sent.
                 if tag.get("type", "").lower() == "file" and multipart:
                     filename = value
-                    if filename != "" and isinstance(filename, string_types):
+                    if filename != "" and isinstance(filename, str):
                         content = open(filename, "rb")
                     else:
                         content = ""

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -1,7 +1,6 @@
 import requests
 import bs4
-from six.moves import urllib
-from six import string_types
+import urllib
 from .form import Form
 import webbrowser
 import tempfile

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -75,8 +75,8 @@ class Browser:
         session handles cookies automatically without calling this function,
         only use this when default cookie handling is insufficient.
 
-        :param cookiejar: Any `cookielib.CookieJar
-          <https://docs.python.org/2/library/cookielib.html#cookielib.CookieJar>`__
+        :param cookiejar: Any `http.cookiejar.CookieJar
+          <https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.CookieJar>`__
           compatible object.
         """
         self.session.cookies = cookiejar

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import copy
 import warnings
 from .utils import LinkNotFoundError
@@ -16,7 +15,7 @@ class InvalidFormMethod(LinkNotFoundError):
     pass
 
 
-class Form(object):
+class Form:
     """Build a fillable form.
 
     :param form: A bs4.element.Tag corresponding to an HTML form element.
@@ -170,7 +169,9 @@ class Form(object):
                     break
             else:
                 raise LinkNotFoundError(
-                    "No input radio named %s with choice %s" % (name, value)
+                    "No input radio named {} with choice {}".format(
+                        name, value
+                    )
                 )
 
     def set_textarea(self, data):
@@ -225,7 +226,9 @@ class Form(object):
 
                 if not option:
                     raise LinkNotFoundError(
-                        'Option %s not found for select %s' % (choice, name)
+                        'Option {} not found for select {}'.format(
+                            choice, name
+                        )
                     )
 
                 option.attrs["selected"] = "selected"
@@ -345,7 +348,7 @@ class Form(object):
             if (inp.has_attr('name') and inp['name'] == submit):
                 if found:
                     raise LinkNotFoundError(
-                        "Multiple submit elements match: {0}".format(submit)
+                        "Multiple submit elements match: {}".format(submit)
                     )
                 found = True
             elif inp == submit:
@@ -361,7 +364,7 @@ class Form(object):
 
         if not found and submit is not None:
             raise LinkNotFoundError(
-                "Specified submit element not found: {0}".format(submit)
+                "Specified submit element not found: {}".format(submit)
             )
         self._submit_chosen = True
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from six.moves import urllib
 from .browser import Browser
 from .utils import LinkNotFoundError
@@ -55,7 +53,7 @@ class StatefulBrowser(Browser):
     """
 
     def __init__(self, *args, **kwargs):
-        super(StatefulBrowser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__debug = False
         self.__verbose = 0
         self.__state = _BrowserState()
@@ -386,4 +384,4 @@ class StatefulBrowser(Browser):
         """
         if soup is None:
             soup = self.page
-        super(StatefulBrowser, self).launch_browser(soup)
+        super().launch_browser(soup)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,10 +1,10 @@
-from six.moves import urllib
 from .browser import Browser
 from .utils import LinkNotFoundError
 from .form import Form
 import sys
 import re
 import bs4
+import urllib
 
 
 class _BrowserState:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests >= 2.0
 beautifulsoup4 >= 4.4
-six >= 1.4
 lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,6 @@
 [aliases]
 test=pytest
 
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1
-
 [tool:pytest]
 # These options allow us to invoke an undecorated pytest to run tests.
 addopts = --cov --cov-config .coveragerc --flake8 -v

--- a/setup.py
+++ b/setup.py
@@ -52,21 +52,20 @@ setup(
 
     license=about['__license__'],
 
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
 
     classifiers=[
         'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
     ],
 
     packages=['mechanicalsoup'],

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -69,7 +69,7 @@ def test_submit_online(httpbin):
     assert data["custname"] == "Customer Name Here"
     assert data["custtel"] == ""  # web browser submits "" for input left blank
     assert data["size"] == "medium"
-    assert set(data["topping"]) == set(("cheese", "onion"))
+    assert set(data["topping"]) == {"cheese", "onion"}
     assert data["comments"] == "Some comment here"
     assert data["nosuchfield"] == "new value"
 
@@ -199,10 +199,10 @@ def test_list_links(capsys):
      <a href="/link1">Link #1</a>
      <a href="/link2" id="link2"> Link #2</a>
 '''
-    browser.open_fake_page('<html>{0}</html>'.format(links))
+    browser.open_fake_page('<html>{}</html>'.format(links))
     browser.list_links()
     out, err = capsys.readouterr()
-    expected = 'Links in the current page:{0}'.format(links)
+    expected = 'Links in the current page:{}'.format(links)
     assert out == expected
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,10 +2,7 @@ import mechanicalsoup
 import requests_mock
 from distutils.version import StrictVersion
 import bs4
-try:
-    from urllib.parse import parse_qsl
-except ImportError:
-    from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 
 """
 Utilities for testing MechanicalSoup.
@@ -62,8 +59,7 @@ def mock_get(mocked_adapter, url, reply, content_type='text/html', **kwargs):
 
 def mock_post(mocked_adapter, url, expected, reply='Success!'):
     def text_callback(request, context):
-        # Python 2's parse_qsl doesn't like None argument
-        query = parse_qsl(request.text) if request.text else []
+        query = parse_qsl(request.text)
         # In bs4 4.7.0+, CSS selectors return elements in page order,
         # but did not in earlier versions.
         if StrictVersion(bs4.__version__) >= StrictVersion('4.7.0'):


### PR DESCRIPTION
Fixes #310.

Also upgrades Python syntax with https://github.com/asottile/pyupgrade, removes the dependency on six, and removes `sudo` from `.travis.yml`, which is no longer needed: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration