### PR TITLE
Upgrade PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - pypy2.7-6.0
-  - pypy3.5-6.0
+  - pypy
+  - pypy3
 install:
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
   - pip install pytest-cov       # needed for the codecov uploader

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Validate all YAML changes, e.g. http://lint.travis-ci.org/
 
-sudo: false
 dist: xenial
 language: python
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ dist: xenial
 language: python
 cache: pip
 python:
+  - pypy
+  - pypy3
   - 2.7
   - 3.5
   - 3.6
   - 3.7
   - 3.8
-  - pypy
-  - pypy3
 install:
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
   - pip install pytest-cov       # needed for the codecov uploader


### PR DESCRIPTION
* `pypy` and `pypy3` now point to PyPy 7
* Test slower PyPy first to speed up the build
* `sudo` is no longer needed: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration