### PR TITLE
form.py: improve warning in Form initialization

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -37,8 +37,8 @@ class Form(object):
         if form.name != 'form':
             warnings.warn(
                 "Constructed a Form from a '{}' instead of a 'form' element. "
-                "This may be an error in a future version of MechanicalSoup.",
-                PendingDeprecationWarning)
+                "This may be an error in a future version of MechanicalSoup."
+                .format(form.name), FutureWarning)
 
         self.form = form
         self._submit_chosen = False

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -11,7 +11,8 @@ def test_construct_form_fail():
     soup = bs4.BeautifulSoup('<notform>This is not a form</notform>', 'lxml')
     tag = soup.find('notform')
     assert isinstance(tag, bs4.element.Tag)
-    pytest.deprecated_call(mechanicalsoup.Form, tag)
+    with pytest.warns(FutureWarning, match="from a 'notform'"):
+        mechanicalsoup.Form(tag)
 
 
 def test_submit_online(httpbin):


### PR DESCRIPTION
The `PendingDeprecationWarning` exception is suppressed by default,
which makes it not very helpful as a way to warn users about likely
incorrect usage. Switch to `FutureWarning`, which is not suppressed
by default.

Also fix a missing string formatting argument.

This would have helped to prevent the mistake made in #315.