### PR TITLE
Properly include examples and logo required for doc build in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE README.rst
 recursive-include tests *.py
-include examples/example*.py
+include examples/*.py
 include requirements.txt tests/requirements.txt
 include docs/*
+include assets/mechanical-soup-logo.png


### PR DESCRIPTION
Fixes the following warnings:
```
docs/index.rst:: WARNING: image file not readable: ../assets/mechanical-soup-logo.png
docs/tutorial.rst:196: WARNING: Include file 'examples/expl_httpbin.py' not found or reading it failed
```