### PR TITLE
Add ability to get form input fields

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -231,7 +231,7 @@ class Form(object):
                 option.attrs["selected"] = "selected"
 
     def __setitem__(self, name, value):
-        """Forwards arguments to :func:`~Form.set`. For example,
+        """Forward arguments to :func:`~Form.set`. For example,
         :code:`form["name"] = "value"` calls :code:`form.set("name", "value")`.
         """
         return self.set(name, value)
@@ -276,6 +276,44 @@ class Form(object):
             self.new_control('text', name, value=value)
             return
         raise LinkNotFoundError("No valid element named " + name)
+
+    def __getitem__(self, name):
+        """Forward arguments to :func:`~Form.get` to get value for a given form field.
+        For example, :code:`name = form["name"]` calls :code:`form.get("name")`
+        """
+        return self.get(name)
+
+    def get(self, name):
+        """Get a ``value`` from input element identified by ``name``.
+        Currently it does support "input" type only.
+
+        Example:
+
+        .. code-block:: python
+            firstname = browser['firstname']
+
+        If the element is not found , raise a :class:`LinkNotFoundError`
+        exception.
+
+"""
+        inp = self.form.find("input", {"name": name})
+        if not inp:
+            raise LinkNotFoundError("No input field named " + name)
+        return inp["value"]
+
+    def __contains__(self, name):
+        """Test if ``name`` input field is in the form.
+        Support "input" type only.
+
+        Example:
+
+        .. code-block:: python
+           if 'name' in form:
+               ...
+
+        """
+        inp = self.form.find("input", {"name": name})
+        return True if inp else False
 
     def new_control(self, type, name, value, **kwargs):
         """Add a new input element to the form.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -119,6 +119,18 @@ class StatefulBrowser(Browser):
         """
         self.form[name] = value
 
+    def __getitem__(self, name):
+        """Get input value of a field in currently selected form.
+        See :func:`Form.__getitem__`.
+        """
+        return self.form[name]
+
+    def __contains__(self, name):
+        """Test if specific field is in the form's input fields.
+        See :func:`Form.__contains__`.
+        """
+        return name in self.form
+
     def new_control(self, type, name, value, **kwargs):
         """Call :func:`Form.new_control` on the currently selected form."""
         return self.form.new_control(type, name, value, **kwargs)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -546,5 +546,45 @@ def test_option_without_value(fail, selected, expected_post):
         assert res.status_code == 200 and res.text == 'Success!'
 
 
+one_field_form = '''<form method="post">
+  <input name="life" type="hidden" value="good"/>
+</form>'''
+
+
+def test_get_value_of_input_field():
+    """Test that we can get input field of current form by name"""
+
+    browser, url = setup_mock_browser(text=one_field_form)
+    browser.open(url)
+    browser.select_form()
+
+    assert browser['life'] == 'good'
+    browser['life'] = 'veryGood'
+    assert browser['life'] == 'veryGood'
+
+
+def test_getting_invalid_field_raises_exception():
+    """Test that we can get input field of current form by name"""
+
+    browser, url = setup_mock_browser(text=one_field_form)
+    browser.open(url)
+    browser.select_form()
+
+    with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+        _ = browser['unknown_life']
+
+
+def test_if_given_field_is_in_current_form():
+    """Test if given input field is one of form input fields"""
+    browser, url = setup_mock_browser(text=one_field_form)
+    browser.open(url)
+    browser.select_form()
+
+    assert 'life' in browser
+    assert 'unknown_life' not in browser
+    browser.new_control('text', 'unknown_life', 'goodToo')
+    assert 'unknown_life' in browser
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
Issue #322 

added ability to get input fields like
`a = browser['a']`

and ability to test if given input field is present in form fields
`if 'field' in browser:
...
`

My first PR, i might have missed something...