### PR TITLE
Fix a tiny type to `set` documenation

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -263,7 +263,7 @@ class Form(object):
 
         .. code-block:: python
 
-            form.set("tagname") = path_to_local_file
+            form.set("tagname", path_to_local_file)
 
         """
         for func in ("checkbox", "radio", "input", "textarea", "select"):


### PR DESCRIPTION
Fix a tiny typo in the documentation explaining how to set a file type input. (The suggested syntax sets a function call to a value.)