### PR TITLE
Add get_request_kwargs to check before requesting

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -139,8 +139,18 @@ class Browser(object):
         Browser.add_soup(response, self.soup_config)
         return response
 
-    def _request(self, form, url=None, **kwargs):
-        """Extract input data from the form to pass to a Requests session."""
+    @staticmethod
+    def _get_request_kwargs(method, url, **kwargs):
+        """This method exists to raise a TypeError when a method or url is
+        specified in the kwargs.
+        """
+        request_kwargs = {"method": method, "url": url}
+        request_kwargs.update(kwargs)
+        return request_kwargs
+
+    @classmethod
+    def get_request_kwargs(cls, form, url=None, **kwargs):
+        """Extract input data from the form."""
         method = str(form.get("method", "get"))
         action = form.get("action")
         url = urllib.parse.urljoin(url, action)
@@ -240,7 +250,12 @@ class Browser(object):
 
             files = DictThatReturnsTrue()
 
-        return self.session.request(method, url, files=files, **kwargs)
+        return cls._get_request_kwargs(method, url, files=files, **kwargs)
+
+    def _request(self, form, url=None, **kwargs):
+        """Extract input data from the form to pass to a Requests session."""
+        request_kwargs = Browser.get_request_kwargs(form, url, **kwargs)
+        return self.session.request(**request_kwargs)
 
     def submit(self, form, url=None, **kwargs):
         """Prepares and sends a form request.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -38,6 +38,40 @@ def test_submit_online(httpbin):
     assert 'MechanicalSoup' in json["headers"]["User-Agent"]
 
 
+def test_get_request_kwargs(httpbin):
+    """Return kwargs without a submit"""
+    browser = mechanicalsoup.Browser()
+    page = browser.get(httpbin + "/forms/post")
+    form = page.soup.form
+    form.find("input", {"name": "custname"})["value"] = "Philip J. Fry"
+    request_kwargs = browser.get_request_kwargs(form, page.url)
+    assert "method" in request_kwargs
+    assert "url" in request_kwargs
+    assert "data" in request_kwargs
+    assert ("custname", "Philip J. Fry") in request_kwargs["data"]
+
+
+def test_get_request_kwargs_when_method_is_in_kwargs(httpbin):
+    """Raise TypeError exception"""
+    browser = mechanicalsoup.Browser()
+    page = browser.get(httpbin + "/forms/post")
+    form = page.soup.form
+    kwargs = {"method": "post"}
+    with pytest.raises(TypeError):
+        browser.get_request_kwargs(form, page.url, **kwargs)
+
+
+def test_get_request_kwargs_when_url_is_in_kwargs(httpbin):
+    """Raise TypeError exception"""
+    browser = mechanicalsoup.Browser()
+    page = browser.get(httpbin + "/forms/post")
+    form = page.soup.form
+    kwargs = {"url": httpbin + "/forms/post"}
+    with pytest.raises(TypeError):
+        # pylint: disable=redundant-keyword-arg
+        browser.get_request_kwargs(form, page.url, **kwargs)
+
+
 def test__request(httpbin):
     form_html = """
     <form method="post" action="{}/post">


### PR DESCRIPTION
When we use mechanicalsoup, we sometimes want to verify a request before submitting it.

If you merge this pull request, the package will be able to provide a way for the package's users to review the request.

This is my first pull request for this project. Please let me know if I'm missing anything.