### PR TITLE
Improve handling of kwargs passed to Requests

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -148,7 +148,10 @@ class Browser(object):
             raise ValueError('no URL to submit to')
 
         # read https://www.w3.org/TR/html52/sec-forms.html
-        data = kwargs.pop("data", dict())
+        if method.lower() == "get":
+            data = kwargs.pop("params", dict())
+        else:
+            data = kwargs.pop("data", dict())
         files = kwargs.pop("files", dict())
 
         # Use a list of 2-tuples to better reflect the behavior of browser QSL.
@@ -254,6 +257,8 @@ class Browser(object):
             relative path, then this must be specified.
         :param \\*\\*kwargs: Arguments forwarded to `requests.Session.request
             <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
+            If `files`, `params` (with GET), or `data` (with POST) are
+            specified, they will be appended to by the contents of `form`.
 
         :return: `requests.Response
             <http://docs.python-requests.org/en/master/api/#requests.Response>`__

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -202,6 +202,19 @@ def test__request_disabled_attr(httpbin):
     assert response.json()['form'] == {}
 
 
+@pytest.mark.parametrize("keyword", [
+    pytest.param('method'),
+    pytest.param('url'),
+])
+def test_request_keyword_error(keyword):
+    """Make sure exception is raised if kwargs duplicates an arg."""
+    form_html = "<form></form>"
+    browser = mechanicalsoup.Browser()
+    with pytest.raises(TypeError, match="multiple values for"):
+        browser._request(BeautifulSoup(form_html, "lxml").form,
+                         'myurl', **{keyword: 'somevalue'})
+
+
 def test_no_404(httpbin):
     browser = mechanicalsoup.Browser()
     resp = browser.get(httpbin + "/nosuchpage")


### PR DESCRIPTION
We pass the form data to requests via `data` for POST methods, and
via `params` for GET methods. Therefore, we should be initializing
our data with the kwargs `data` or `params` respectively (whereas
previously we were initializing with `data` only).

Also added tests to check that we raise an exception when the kwargs
include a parameter that duplicates one of the args that we manually
set (i.e. `url` or `method`).