### PR TITLE
Drop support for EOL Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 cache: pip
 python:
   - pypy3
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,11 @@ Release Notes
 Version 1.1 (in development)
 ============================
 
+Main changes
+------------
+
+* Dropped support for EOL Python versions: 2.7 and 3.5.
+
 Version 1.0
 ===========
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -90,9 +90,7 @@ class Browser:
         # set a default user_agent if not specified
         if user_agent is None:
             requests_ua = requests.utils.default_user_agent()
-            user_agent = '{} ({}/{})'.format(
-                requests_ua, __title__, __version__
-            )
+            user_agent = f'{requests_ua} ({__title__}/{__version__})'
 
         # the requests module uses a case-insensitive dict for session headers
         self.session.headers['User-agent'] = user_agent
@@ -173,7 +171,7 @@ class Browser:
 
         # Process form tags in the order that they appear on the page,
         # skipping those tags that do not have a name-attribute.
-        selector = ",".join("{}[name]".format(i) for i in
+        selector = ",".join(f"{tag}[name]" for tag in
                             ("input", "button", "textarea", "select"))
         for tag in form.select(selector):
             name = tag.get("name")  # name-attribute of tag

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -35,9 +35,9 @@ class Form:
     def __init__(self, form):
         if form.name != 'form':
             warnings.warn(
-                "Constructed a Form from a '{}' instead of a 'form' element. "
-                "This may be an error in a future version of MechanicalSoup."
-                .format(form.name), FutureWarning)
+                f"Constructed a Form from a '{form.name}' instead of a 'form' "
+                " element. This may be an error in a future version of "
+                "MechanicalSoup.", FutureWarning)
 
         self.form = form
         self._submit_chosen = False
@@ -169,9 +169,7 @@ class Form:
                     break
             else:
                 raise LinkNotFoundError(
-                    "No input radio named {} with choice {}".format(
-                        name, value
-                    )
+                    f"No input radio named {name} with choice {value}"
                 )
 
     def set_textarea(self, data):
@@ -226,9 +224,7 @@ class Form:
 
                 if not option:
                     raise LinkNotFoundError(
-                        'Option {} not found for select {}'.format(
-                            choice, name
-                        )
+                        f'Option {choice} not found for select {name}'
                     )
 
                 option.attrs["selected"] = "selected"
@@ -348,7 +344,7 @@ class Form:
             if (inp.has_attr('name') and inp['name'] == submit):
                 if found:
                     raise LinkNotFoundError(
-                        "Multiple submit elements match: {}".format(submit)
+                        f"Multiple submit elements match: {submit}"
                     )
                 found = True
             elif inp == submit:
@@ -364,7 +360,7 @@ class Form:
 
         if not found and submit is not None:
             raise LinkNotFoundError(
-                "Specified submit element not found: {}".format(submit)
+                f"Specified submit element not found: {submit}"
             )
         self._submit_chosen = True
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     license=about['__license__'],
 
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 
     classifiers=[
         'License :: OSI Approved :: MIT License',
@@ -60,7 +60,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -73,8 +73,8 @@ def test_get_request_kwargs_when_url_is_in_kwargs(httpbin):
 
 
 def test__request(httpbin):
-    form_html = """
-    <form method="post" action="{}/post">
+    form_html = f"""
+    <form method="post" action="{httpbin.url}/post">
       <input name="customer" value="Philip J. Fry"/>
       <input name="telephone" value="555"/>
       <textarea name="comments">freezer</textarea>
@@ -96,7 +96,7 @@ def test__request(httpbin):
         <option value="square" selected>Square</option>
       </select>
     </form>
-    """.format(httpbin.url)
+    """
 
     form = BeautifulSoup(form_html, "lxml").form
 
@@ -137,12 +137,12 @@ default_enctype = "application/x-www-form-urlencoded"
 def test_enctype_and_file_submit(httpbin, enctype, submit_file, file_field):
     # test if enctype is respected when specified
     # and if files are processed correctly
-    form_html = """
-    <form method="post" action="{}/post" enctype="{}">
+    form_html = f"""
+    <form method="post" action="{httpbin.url}/post" enctype="{enctype}">
       <input name="in" value="test" />
-      {}
+      {file_field}
     </form>
-    """.format(httpbin.url, enctype, file_field)
+    """
     form = BeautifulSoup(form_html, "lxml").form
 
     valid_enctype = (enctype in valid_enctypes_file_submit and
@@ -210,13 +210,13 @@ def test_enctype_and_file_submit(httpbin, enctype, submit_file, file_field):
 def test__request_select_none(httpbin):
     """Make sure that a <select> with no options selected
     submits the first option, as it does in a browser."""
-    form_html = """
-    <form method="post" action={}/post>
+    form_html = f"""
+    <form method="post" action={httpbin.url}/post>
       <select name="shape">
         <option value="round">Round</option>
         <option value="square">Square</option>
       </select>
-    </form>""".format(httpbin.url)
+    </form>"""
 
     form = BeautifulSoup(form_html, "lxml").form
     browser = mechanicalsoup.Browser()
@@ -226,10 +226,10 @@ def test__request_select_none(httpbin):
 
 def test__request_disabled_attr(httpbin):
     """Make sure that disabled form controls are not submitted."""
-    form_html = """
-    <form method="post" action="{}/post">
+    form_html = f"""
+    <form method="post" action="{httpbin.url}/post">
       <input disabled name="nosubmit" value="1" />
-    </form>""".format(httpbin.url)
+    </form>"""
 
     browser = mechanicalsoup.Browser()
     response = browser._request(BeautifulSoup(form_html, "lxml").form)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -117,7 +117,7 @@ def test_choose_submit_from_selector(value):
     browser, url = setup_mock_browser(expected_post=[('do', value)], text=text)
     browser.open(url)
     form = browser.select_form()
-    submits = form.form.select('input[value="{}"]'.format(value))
+    submits = form.form.select(f'input[value="{value}"]')
     assert len(submits) == 1
     form.choose_submit(submits[0])
     res = browser.submit_selected()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -199,10 +199,10 @@ def test_list_links(capsys):
      <a href="/link1">Link #1</a>
      <a href="/link2" id="link2"> Link #2</a>
 '''
-    browser.open_fake_page('<html>{}</html>'.format(links))
+    browser.open_fake_page(f'<html>{links}</html>')
     browser.list_links()
     out, err = capsys.readouterr()
-    expected = 'Links in the current page:{}'.format(links)
+    expected = f'Links in the current page:{links}'
     assert out == expected
 
 
@@ -610,7 +610,7 @@ def test_refresh_open():
 def test_refresh_follow_link():
     url = 'mock://example.com'
     follow_url = 'mock://example.com/followed'
-    initial_content = '<a href="{url}">Link</a>'.format(url=follow_url)
+    initial_content = f'<a href="{follow_url}">Link</a>'
     initial_page = BeautifulSoup(initial_content, 'lxml')
     reload_page = BeautifulSoup('<p>Fake reloaded page</p>', 'lxml')
 


### PR DESCRIPTION
This also allows us to replace `.format()` with f-strings.