### PR TITLE
Bump minimum requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests >= 2.0
+requests >= 2.22.0
 beautifulsoup4 >= 4.4
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests >= 2.22.0
-beautifulsoup4 >= 4.4
+beautifulsoup4 >= 4.7
 lxml


### PR DESCRIPTION
* requests >= 2.22.0 [#282]
* beautifulsoup4 >= 4.7 [#244]

These versions are pretty old at this point, so there is little downside to bumping the minimum requirements, especially since they are well-motivated.