### PR TITLE
Add pytest minimum version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ python:
   - 3.8
   - 3.9
 install:
-  - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
-  - pip install pytest-cov       # needed for the codecov uploader
   - pip install -r requirements.txt -r tests/requirements.txt
 script:
   # Do not perform flake8 checks in pypy environments (see issue #146)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
-pytest
+pytest >= 3.1.0
 pytest-cov
 pytest-flake8
 pytest-httpbin
 pytest-mock
-requests_mock>=1.3.0
+requests_mock >= 1.3.0


### PR DESCRIPTION
Explicitly require pytest >= 3.1.0 in tests/requirements.txt, due to
the use of `pytest.param`.

This ensures a compatible local testing environment, and allows us to
remove the manual pytest upgrade for Travis-CI. (We also remove the
manual pytest-cov installation, because that is already handled by
the tests/requirements.txt file.)