### PR TITLE
Use encoding from the HTTP request when no HTML encoding is specified

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,8 +53,11 @@ def prepare_mock_browser(scheme='mock'):
 
 def mock_get(mocked_adapter, url, reply, content_type='text/html', **kwargs):
     headers = {'Content-Type': content_type}
-    mocked_adapter.register_uri('GET', url, headers=headers, text=reply,
-                                **kwargs)
+    if isinstance(reply, str):
+        kwargs['text'] = reply
+    else:
+        kwargs['content'] = reply
+    mocked_adapter.register_uri('GET', url, headers=headers, **kwargs)
 
 
 def mock_post(mocked_adapter, url, expected, reply='Success!'):


### PR DESCRIPTION
Hi,

Here is a PR for fixing #354, along with tests. Httpbin offers a testing endpoint defining encoding at the HTTP level, but not through a HTML tag (precisely the error initially described in #354). I did not find any testing endpoints to use for other cases ("no HTTP encoding, HTML one" and "both of them").

Best,