### PR TITLE
submit_selected(): Don't override user's Referer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 from datetime import datetime
 
 
@@ -23,6 +23,7 @@ from datetime import datetime
 sys.path.insert(0, os.path.abspath('..'))
 
 import mechanicalsoup
+
 
 # -- General configuration ------------------------------------------------
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -3,8 +3,10 @@
 NOTE: This example will not work if the user has 2FA enabled."""
 
 import argparse
-import mechanicalsoup
 from getpass import getpass
+
+import mechanicalsoup
+
 
 parser = argparse.ArgumentParser(description="Login to GitHub.")
 parser.add_argument("username")

--- a/examples/example_manual.py
+++ b/examples/example_manual.py
@@ -2,7 +2,9 @@
 
 See example.py for an example using the more advanced StatefulBrowser."""
 import argparse
+
 import mechanicalsoup
+
 
 parser = argparse.ArgumentParser(description="Login to GitHub.")
 parser.add_argument("username")

--- a/examples/expl_duck_duck_go.py
+++ b/examples/expl_duck_duck_go.py
@@ -4,6 +4,7 @@ Example usage of MechanicalSoup to get the results from DuckDuckGo.
 
 import mechanicalsoup
 
+
 # Connect to duckduckgo
 browser = mechanicalsoup.StatefulBrowser(user_agent="MechanicalSoup")
 browser.open("https://duckduckgo.com/")

--- a/examples/expl_google.py
+++ b/examples/expl_google.py
@@ -1,5 +1,7 @@
 import re
+
 import mechanicalsoup
+
 
 # Connect to Google
 browser = mechanicalsoup.StatefulBrowser()

--- a/examples/expl_httpbin.py
+++ b/examples/expl_httpbin.py
@@ -1,5 +1,6 @@
 import mechanicalsoup
 
+
 browser = mechanicalsoup.StatefulBrowser()
 browser.open("http://httpbin.org/")
 

--- a/examples/expl_qwant.py
+++ b/examples/expl_qwant.py
@@ -3,8 +3,10 @@ search engine.
 """
 
 import re
-import mechanicalsoup
 import urllib.parse
+
+import mechanicalsoup
+
 
 # Connect to duckduckgo
 browser = mechanicalsoup.StatefulBrowser(user_agent='MechanicalSoup')

--- a/mechanicalsoup/__init__.py
+++ b/mechanicalsoup/__init__.py
@@ -1,8 +1,9 @@
-from .utils import LinkNotFoundError
+from .__version__ import __version__
 from .browser import Browser
 from .form import Form, InvalidFormMethod
 from .stateful_browser import StatefulBrowser
-from .__version__ import __version__
+from .utils import LinkNotFoundError
+
 
 __all__ = ['StatefulBrowser', 'LinkNotFoundError', 'Browser', 'Form',
            'InvalidFormMethod', '__version__']

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -1,13 +1,15 @@
-import requests
+import tempfile
+import urllib
+import weakref
+import webbrowser
+
 import bs4
 import bs4.dammit
-import urllib
+import requests
+
+from .__version__ import __title__, __version__
 from .form import Form
-import webbrowser
-import tempfile
 from .utils import LinkNotFoundError
-from .__version__ import __version__, __title__
-import weakref
 
 
 class Browser:

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -1,7 +1,9 @@
 import copy
 import warnings
-from .utils import LinkNotFoundError
+
 from bs4 import BeautifulSoup
+
+from .utils import LinkNotFoundError
 
 
 class InvalidFormMethod(LinkNotFoundError):

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,10 +1,12 @@
-from .browser import Browser
-from .utils import LinkNotFoundError
-from .form import Form
-import sys
 import re
-import bs4
+import sys
 import urllib
+
+import bs4
+
+from .browser import Browser
+from .form import Form
+from .utils import LinkNotFoundError
 
 
 class _BrowserState:

--- a/tests/setpath.py
+++ b/tests/setpath.py
@@ -1,8 +1,9 @@
 """Add the main directory of the project to sys.path, so that
 uninstalled version is tested."""
 
-import sys
 import os
+import sys
+
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 PROJ_DIR = os.path.dirname(TEST_DIR)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,16 +1,14 @@
-import setpath  # noqa:F401, must come before 'import mechanicalsoup'
-import mechanicalsoup
-import sys
-from bs4 import BeautifulSoup
-import tempfile
 import os
-from requests.cookies import RequestsCookieJar
-import pytest
+import sys
+import tempfile
 
-from utils import (
-    prepare_mock_browser,
-    mock_get
-)
+import pytest
+import setpath  # noqa:F401, must come before 'import mechanicalsoup'
+from bs4 import BeautifulSoup
+from requests.cookies import RequestsCookieJar
+from utils import mock_get, prepare_mock_browser
+
+import mechanicalsoup
 
 
 def test_submit_online(httpbin):

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,9 +1,11 @@
-import setpath  # noqa:F401, must come before 'import mechanicalsoup'
-import mechanicalsoup
-import bs4
-from utils import setup_mock_browser
 import sys
+
+import bs4
 import pytest
+import setpath  # noqa:F401, must come before 'import mechanicalsoup'
+from utils import setup_mock_browser
+
+import mechanicalsoup
 
 
 def test_construct_form_fail():

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -166,6 +167,21 @@ def test_submit_btnName(expected_post):
     res = browser.submit_selected(btnName=expected_post[2][0])
     assert res.status_code == 200 and res.text == 'Success!'
     assert initial_state != browser._StatefulBrowser__state
+
+
+def test_submit_dont_modify_kwargs():
+    """Test that submit_selected() doesn't modify the caller's passed-in
+    kwargs, for example when adding a Referer header.
+    """
+    kwargs = {'headers': {'Content-Type': 'text/html'}}
+    saved_kwargs = copy.deepcopy(kwargs)
+
+    browser, url = setup_mock_browser(expected_post=[], text='<form></form>')
+    browser.open(url)
+    browser.select_form()
+    browser.submit_selected(**kwargs)
+
+    assert kwargs == saved_kwargs
 
 
 def test_submit_dont_update_state():
@@ -444,6 +460,26 @@ def test_referer_submit(httpbin):
     referer = headers["Referer"]
     actual_ref = re.sub('/*$', '', referer)
     assert actual_ref == ref
+
+
+@pytest.mark.parametrize("referer_header", ["Referer", "referer"])
+def test_referer_submit_override(httpbin, referer_header):
+    """Ensure the caller can override the Referer header that
+    mechanicalsoup would normally add. Because headers are case insensitive,
+    test with both 'Referer' and 'referer'.
+    """
+
+    browser = mechanicalsoup.StatefulBrowser()
+    ref = "https://example.com/my-referer"
+    ref_override = "https://example.com/override"
+    page = submit_form_headers.format(httpbin.url + "/headers")
+    browser.open_fake_page(page, url=ref)
+    browser.select_form()
+    response = browser.submit_selected(headers={referer_header: ref_override})
+    headers = response.json()["headers"]
+    referer = headers["Referer"]
+    actual_ref = re.sub('/*$', '', referer)
+    assert actual_ref == ref_override
 
 
 def test_referer_submit_headers(httpbin):

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,19 +1,17 @@
-import os
-import tempfile
 import json
-import setpath  # noqa:F401, must come before 'import mechanicalsoup'
-import mechanicalsoup
-import sys
+import os
 import re
-from bs4 import BeautifulSoup
-from utils import (
-    setup_mock_browser,
-    prepare_mock_browser,
-    mock_get,
-    open_legacy_httpbin
-)
-import pytest
+import sys
+import tempfile
 import webbrowser
+
+import pytest
+import setpath  # noqa:F401, must come before 'import mechanicalsoup'
+from bs4 import BeautifulSoup
+from utils import (mock_get, open_legacy_httpbin, prepare_mock_browser,
+                   setup_mock_browser)
+
+import mechanicalsoup
 
 
 def test_request_forward():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-import mechanicalsoup
 import pytest
+
+import mechanicalsoup
 
 
 def test_LinkNotFoundError():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,11 @@
-import mechanicalsoup
-import requests_mock
 from distutils.version import StrictVersion
-import bs4
 from urllib.parse import parse_qsl
+
+import bs4
+import requests_mock
+
+import mechanicalsoup
+
 
 """
 Utilities for testing MechanicalSoup.


### PR DESCRIPTION
(This is not intended to be squashed; I can break it into two PRs if that's better)

* prereq: Sort and group all imports per PEP8 (isort)
* actual: submit_selected(): Referer fixes

Don't override a Referer field that a user passes in.
Note that since HTTP headers are case-insensitive, use requests'
CaseInsensitiveDict to handle this.

Futhermore, don't modify the caller's **kwargs, the caller should
assume we do not modify the submitted dict, so make a copy
first.

Do this in _merge_referer() helper function, as we anticipate needing
this in other functions when #362 is fixed.

Add a test for overriding Referers.


This was raised in https://github.com/MechanicalSoup/MechanicalSoup/issues/362#issuecomment-812921602