### PR TITLE
bugfix : Line 76, in add_soup : if 'charset' in response.headers.get(…

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -73,7 +73,7 @@ class Browser:
             # resort to bs4 sniffing, hence the special handling here.
             http_encoding = (
                 response.encoding
-                if 'charset' in response.headers.get("Content-Type")
+                if 'charset' in response.headers.get("Content-Type", "")
                 else None
             )
             html_encoding = bs4.dammit.EncodingDetector.find_declared_encoding(


### PR DESCRIPTION
Line 76, in add_soup : if 'charset' in response.headers.get(Content-Type) leads to TypeError: argument of type 'NoneType' is not iterable if response.headers.get(Content-Type) is not defined and Browser.__looks_like_html(response) is True