### PR TITLE
stateful_browser: {follow,download}_link: Allow requests_kwargs

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -10,6 +10,14 @@ Main changes
 
 * Dropped support for EOL Python versions: 2.7 and 3.5.
 
+* ``StatefulBrowser`` methods ``follow_link`` and ``download_link``
+  now support passing a dictionary of keyword arguments to
+  ``requests``, via ``requests_kwargs``. For symmetry, they also
+  support passing Beautiful Soup args in as ``bs4_kwargs``, although
+  any excess ``**kwargs`` are sent to Beautiful Soup as well, just as
+  they were previously.
+
+
 Version 1.0
 ===========
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -236,7 +236,7 @@ class StatefulBrowser(Browser):
         return kwargs
 
     def submit_selected(self, btnName=None, update_state=True,
-                        *args, **kwargs):
+                        **kwargs):
         """Submit the form that was selected with :func:`select_form`.
 
         :return: Forwarded from :func:`Browser.submit`.
@@ -252,7 +252,7 @@ class StatefulBrowser(Browser):
 
         kwargs = self._merge_referer(**kwargs)
         resp = self.submit(self.__state.form, url=self.__state.url,
-                           *args, **kwargs)
+                           **kwargs)
         if update_state:
             self.__state = _BrowserState(page=resp.soup, url=resp.url,
                                          request=resp.request)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -329,7 +329,8 @@ class StatefulBrowser(Browser):
                 self.launch_browser()
             raise
 
-    def follow_link(self, link=None, *args, **kwargs):
+    def follow_link(self, link=None, *bs4_args, bs4_kwargs={},
+                    requests_kwargs={},  **kwargs):
         """Follow a link.
 
         If ``link`` is a bs4.element.Tag (i.e. from a previous call to
@@ -337,22 +338,28 @@ class StatefulBrowser(Browser):
 
         If ``link`` doesn't have a *href*-attribute or is None, treat
         ``link`` as a url_regex and look it up with :func:`find_link`.
-        Any additional arguments specified are forwarded to this function.
+        ``bs4_kwargs`` are forwarded to :func:`find_link`.
+        For backward compatibility, any excess keyword arguments
+        (aka ``**kwargs``)
+        are also forwarded to :func:`find_link`.
 
         If the link is not found, raise :class:`LinkNotFoundError`.
         Before raising, if debug is activated, list available links in the
         page and launch a browser.
 
+        ``requests_kwargs`` are forwarded to :func:`open_relative`.
+
         :return: Forwarded from :func:`open_relative`.
         """
-        link = self._find_link_internal(link, args, kwargs)
+        link = self._find_link_internal(link, bs4_args,
+                                        {**bs4_kwargs, **kwargs})
 
-        referer = self.url
-        headers = {'Referer': referer} if referer else None
+        requests_kwargs = self._merge_referer(**requests_kwargs)
 
-        return self.open_relative(link['href'], headers=headers)
+        return self.open_relative(link['href'], **requests_kwargs)
 
-    def download_link(self, link=None, file=None, *args, **kwargs):
+    def download_link(self, link=None, file=None, *bs4_args, bs4_kwargs={},
+                      requests_kwargs={}, **kwargs):
         """Downloads the contents of a link to a file. This function behaves
         similarly to :func:`follow_link`, but the browser state will
         not change when calling this function.
@@ -361,20 +368,22 @@ class StatefulBrowser(Browser):
             downloaded. If the file already exists, it will be overwritten.
 
         Other arguments are the same as :func:`follow_link` (``link``
-        can either be a bs4.element.Tag or a URL regex, other
-        arguments are forwarded to :func:`find_link`).
+        can either be a bs4.element.Tag or a URL regex.
+        ``bs4_kwargs`` arguments are forwarded to :func:`find_link`,
+        as are any excess keyword arguments (aka ``**kwargs``) for backwards
+        compatibility).
 
         :return: `requests.Response
             <http://docs.python-requests.org/en/master/api/#requests.Response>`__
             object.
         """
-        link = self._find_link_internal(link, args, kwargs)
+        link = self._find_link_internal(link, bs4_args,
+                                        {**bs4_kwargs, **kwargs})
         url = self.absolute_url(link['href'])
 
-        referer = self.url
-        headers = {'Referer': referer} if referer else None
+        requests_kwargs = self._merge_referer(**requests_kwargs)
 
-        response = self.session.get(url, headers=headers)
+        response = self.session.get(url, **requests_kwargs)
         if self.raise_on_404 and response.status_code == 404:
             raise LinkNotFoundError()
 

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -506,7 +506,7 @@ def test_follow_link_arg(httpbin, expected, kwargs):
     browser = mechanicalsoup.StatefulBrowser()
     html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
     browser.open_fake_page(html, httpbin.url)
-    browser.follow_link(**kwargs)
+    browser.follow_link(bs4_kwargs=kwargs)
     assert browser.url == httpbin + expected
 
 
@@ -544,7 +544,7 @@ def test_link_arg_multiregex(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
     browser.open_fake_page('<a href="/get">Link</a>', httpbin.url)
     with pytest.raises(ValueError, match="link parameter cannot be .*"):
-        browser.follow_link('foo', url_regex='bar')
+        browser.follow_link('foo', bs4_kwargs={'url_regex': 'bar'})
 
 
 def file_get_contents(filename):

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -510,6 +510,36 @@ def test_follow_link_arg(httpbin, expected, kwargs):
     assert browser.url == httpbin + expected
 
 
+def test_follow_link_excess(httpbin):
+    """Ensure that excess args are passed to BeautifulSoup"""
+    browser = mechanicalsoup.StatefulBrowser()
+    html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
+    browser.open_fake_page(html, httpbin.url)
+    browser.follow_link(url_regex='get')
+    assert browser.url == httpbin + '/get'
+
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<a href="/get">Link</a>', httpbin.url)
+    with pytest.raises(ValueError, match="link parameter cannot be .*"):
+        browser.follow_link('foo', url_regex='bar')
+
+
+def test_follow_link_ua(httpbin):
+    """Tests passing requests parameters to follow_link() by
+    setting the User-Agent field."""
+    browser = mechanicalsoup.StatefulBrowser()
+    # html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
+    # browser.open_fake_page(html, httpbin.url)
+    browser.open(httpbin.url)
+    bs4_kwargs = {'url_regex': 'user-agent'}
+    requests_kwargs = {'headers': {"User-Agent": '007'}}
+    resp = browser.follow_link(bs4_kwargs=bs4_kwargs,
+                               requests_kwargs=requests_kwargs)
+    assert browser.url == httpbin + '/user-agent'
+    assert resp.json() == {'user-agent': '007'}
+    assert resp.request.headers['user-agent'] == '007'
+
+
 def test_link_arg_multiregex(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
     browser.open_fake_page('<a href="/get">Link</a>', httpbin.url)
@@ -557,6 +587,58 @@ def test_download_link_nofile(httpbin):
 
     # Check that we actually downloaded a PNG file
     assert response.content[:4] == b'\x89PNG'
+
+
+def test_download_link_nofile_bs4(httpbin):
+    """Test downloading the contents of a link without saving it."""
+    browser = mechanicalsoup.StatefulBrowser()
+    open_legacy_httpbin(browser, httpbin)
+    current_url = browser.url
+    current_page = browser.page
+    response = browser.download_link(bs4_kwargs={'url_regex': 'image.png'})
+
+    # Check that the browser state has not changed
+    assert browser.url == current_url
+    assert browser.page == current_page
+
+    # Check that we actually downloaded a PNG file
+    assert response.content[:4] == b'\x89PNG'
+
+
+def test_download_link_nofile_excess(httpbin):
+    """Test downloading the contents of a link without saving it."""
+    browser = mechanicalsoup.StatefulBrowser()
+    open_legacy_httpbin(browser, httpbin)
+    current_url = browser.url
+    current_page = browser.page
+    response = browser.download_link(url_regex='image.png')
+
+    # Check that the browser state has not changed
+    assert browser.url == current_url
+    assert browser.page == current_page
+
+    # Check that we actually downloaded a PNG file
+    assert response.content[:4] == b'\x89PNG'
+
+
+def test_download_link_nofile_ua(httpbin):
+    """Test downloading the contents of a link without saving it."""
+    browser = mechanicalsoup.StatefulBrowser()
+    open_legacy_httpbin(browser, httpbin)
+    current_url = browser.url
+    current_page = browser.page
+    requests_kwargs = {'headers': {"User-Agent": '007'}}
+    response = browser.download_link(link='image/png',
+                                     requests_kwargs=requests_kwargs)
+    # Check that the browser state has not changed
+    assert browser.url == current_url
+    assert browser.page == current_page
+
+    # Check that we actually downloaded a PNG file
+    assert response.content[:4] == b'\x89PNG'
+
+    # Check that we actually set the User-agent outbound
+    assert response.request.headers['user-agent'] == '007'
 
 
 def test_download_link_to_existing_file(httpbin):


### PR DESCRIPTION
Addresses #362: browser.follow_link() has no way to pass kwargs to requests
Accept keywords args in three ways:
  bs4_kwargs	  Explicitly passed to Beautiful Soup, via find_link, &c.
  requests_kwargs Passed to requests, via open_relative
  **kwargs	  Excess args, merged with bs4_kwargs for backwards
  		  compatibility

Adjust docstrings as appropriate.

Rename *args to *bs4_args to more clearly indicate that these positional
args go to the bs4 functions not to the requests functions.

Add tests:
test_download_link_nofile_bs4
  passes args to BeautifulSoup via bs4_kwargs
test_download_link_nofile_excess
  passes args to BeautifulSoup via excess **kwargs
test_follow_link_ua()
test_download_link_nofile_ua()
  both of which pass in requests_kwargs that set the User-Agent header

