### PR TITLE
stateful_browser.py: add a response property

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -10,13 +10,17 @@ Main changes
 
 * Dropped support for EOL Python versions: 2.7 and 3.5.
 
+* ``StatefulBrowser`` now has a ``response`` property that stores the
+  response related to the current browser state.
+  [`#358 <https://github.com/MechanicalSoup/MechanicalSoup/issues/358>`__]
+
 * ``StatefulBrowser`` methods ``follow_link`` and ``download_link``
   now support passing a dictionary of keyword arguments to
   ``requests``, via ``requests_kwargs``. For symmetry, they also
   support passing Beautiful Soup args in as ``bs4_kwargs``, although
   any excess ``**kwargs`` are sent to Beautiful Soup as well, just as
   they were previously.
-
+  [`#362 <https://github.com/MechanicalSoup/MechanicalSoup/issues/362>`__]
 
 Version 1.0
 ===========

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -35,6 +35,12 @@ def test_properties():
     assert browser.form is not None
 
 
+def test_state_has_no_response():
+    browser = mechanicalsoup.StatefulBrowser()
+    with pytest.raises(AttributeError, match="No request has been made yet."):
+        browser.response
+
+
 def test_get_selected_form_unselected():
     browser = mechanicalsoup.StatefulBrowser()
     browser.open_fake_page('<form></form>')
@@ -167,6 +173,8 @@ def test_submit_btnName(expected_post):
     res = browser.submit_selected(btnName=expected_post[2][0])
     assert res.status_code == 200 and res.text == 'Success!'
     assert initial_state != browser._StatefulBrowser__state
+    # Make sure the returned response is stored in the browser state
+    assert res == browser.response
 
 
 def test_submit_dont_modify_kwargs():


### PR DESCRIPTION
Whenever we set the browser state, include the request response.
The `response` property will raise an `AttributeError` if the state
has not yet been set.

This is not strictly necessary, since we return the request response
in most functions that have one, but it is perhaps a convenience in
some scenarios.

Closes #358.