### PR TITLE
stop submitting absolute file path for file uploads

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import urllib
 import weakref
@@ -228,11 +229,12 @@ class Browser:
                 # If the enctype is not multipart, the filename is put in
                 # the form as a text input and the file is not sent.
                 if tag.get("type", "").lower() == "file" and multipart:
-                    filename = value
-                    if filename != "" and isinstance(filename, str):
-                        content = open(filename, "rb")
+                    filepath = value
+                    if filepath != "" and isinstance(filepath, str):
+                        content = open(filepath, "rb")
                     else:
                         content = ""
+                    filename = os.path.basename(filepath)
                     # If value is the empty string, we still pass it
                     # for consistency with browsers (see
                     # https://github.com/MechanicalSoup/MechanicalSoup/issues/250).

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -155,6 +155,7 @@ def test_enctype_and_file_submit(httpbin, enctype, submit_file, file_field):
         # create a temporary file for testing file upload
         file_content = b":-)"
         pic_filedescriptor, pic_path = tempfile.mkstemp()
+        pic_filename = os.path.basename(pic_path)
         os.write(pic_filedescriptor, file_content)
         os.close(pic_filedescriptor)
         if valid_enctype:
@@ -199,7 +200,7 @@ def test_enctype_and_file_submit(httpbin, enctype, submit_file, file_field):
         if valid_enctype:
             assert found_in == "files"
             if submit_file:
-                assert ("filename=\"" + pic_path + "\""
+                assert ("filename=\"" + pic_filename + "\""
                         ).encode() in response.request.body
             else:
                 assert b"filename=\"\"" in response.request.body


### PR DESCRIPTION
I noticed that MechanicalSoup is submitting the full local file path of the uploaded file to the server, while other browsers are only sending the filename. This behavior might leak more information to the server than the user is expecting.

I checked the [HTML Spec for "File Upload state"](https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)) (I think that is the applicable reference to check?), and it says:

> Filenames must not contain path components, even in the case that a user has selected an entire directory hierarchy or multiple files with the same name from different directories. Path components, for the purposes of the File Upload state, are those parts of filenames that are separated by U+005C REVERSE SOLIDUS character (\\) characters.

This PR aims to fix this by extracting the filename using `os.path.basename`, which should work on all systems. Then it only submits `filename`, and renames the old `filename` variable to `filepath`, to avoid confusions in the future.

To show the difference I set up a little Flask webserver. It just prints the uploaded file information and the user-agent, and I tested it with Firefox, Chrome, and the MechanicalSoup StatefulBrowser:
<details>
<summary>This is the log output:</summary>

```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36
ImmutableMultiDict([('file_input', <FileStorage: 'mech.py' ('text/plain')>)])
127.0.0.1 - - [09/Jun/2021 21:54:06] "POST /upload HTTP/1.1" 200 -
127.0.0.1 - - [09/Jun/2021 21:54:16] "GET / HTTP/1.1" 200 -
python-requests/2.25.1 (MechanicalSoup/1.1.0)
ImmutableMultiDict([('file_input', <FileStorage: '/home/dubbl/work/tmp/mech.py' (None)>)])
127.0.0.1 - - [09/Jun/2021 21:54:16] "POST /upload HTTP/1.1" 200 -
Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
ImmutableMultiDict([('file', <FileStorage: 'mech.py' ('text/plain')>)])
127.0.0.1 - - [09/Jun/2021 21:54:26] "POST /upload HTTP/1.1" 200 -
```
</details>

I'd be happy to get feedback on this PR, as it is my first one for this project.