### PR TITLE
Fix coverage uploading with codecov-action@v2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,23 +16,32 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install -r tests/requirements.txt
+
     - name: Test with pytest without flake8 (for pypy)
       if: startsWith(matrix.python-version, 'pypy')
-      run: |
-        # We run pytest without the lint with flake8 in the pypy version, otherwise, the worflow takes too long time to execute.
-        pytest -o 'flake8-ignore=*.py ALL' 
+      # flake8 runs very slowly with pypy, so skip it (see #146)
+      run: pytest -o 'flake8-ignore=*.py ALL'
+
     - name: Test with pytest
       if: startsWith(matrix.python-version, 'pypy') != true
-      run: |
-        pytest
-    - name: Upload Coverage to Codecov
+      run: pytest
+
+    - name: Generate coverage report
+      run: coverage xml
+
+    - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true
+        verbose: true


### PR DESCRIPTION
The codecov-action@v2 does not automatically generate the XML coverage
report (unlike v1), so we need to generate it ourselves by running:

  coverage xml

This generates a `coverage.xml` file from the binary `.coverage` file
written by pytest. We will now also fail the CI if the codecov upload
fails, to help catch issues like this more easily.

Note that we could have added `--cov-report=xml` to the pytest options
in `setup.cfg`, but the XML coverage file is not generally useful to
devs running pytest locally. We also could have added it to the pytest
invocation in the test workflow, but we would have needed to repeat it
twice due to the pypy-specific step.