### PR TITLE
Prevent test workflow from triggering twice

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,13 @@
 
 name: Build and Test
 
-on: [push, pull_request]
+# Run workflow for pushes to main and version branches, or pull requests
+on:
+  push:
+    branches:
+      - main
+      - 'v[0-9.]+'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Restrict the branches on which the test workflow is triggered by pushes
so that we don't trigger it twice on PR branches that are created in
the upstream repository.

In general, most developers will create the PR branch in their fork,
but this is not the case for, e.g., PRs that dependabot creates.