### PR TITLE
Speed up workflow with pip cache

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Installing pip dependencies constitutes about half of our workflow
runtime, so using the builtin pip cache from the `setup-python` action
may make our CI faster. The workflows will need to be monitored to
assess the effectiveness of the cache.

GitHub will purge the cache if it goes unused for a certain amount of
time (presently 7 days).