### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
     long_description=read('README.rst', about['__github_url__'], about[
         '__github_assets_absoluteURL__']),
     url=about['__url__'],
+    project_urls={
+        'Source': 'https://github.com/MechanicalSoup/MechanicalSoup',
+    },
 
     license=about['__license__'],
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         '__github_assets_absoluteURL__']),
     url=about['__url__'],
     project_urls={
-        'Source': 'https://github.com/MechanicalSoup/MechanicalSoup',
+        'Source': about['__github_url__'],
     },
 
     license=about['__license__'],


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)