### PR TITLE
Add werkzeug version in tests/requirements.txt file

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-flake8
 pytest-httpbin
 pytest-mock
 requests_mock >= 1.3.0
+werkzeug < 2.1.0


### PR DESCRIPTION
In the continuous integration workflow, when pytest runs and calls httpbin, there was an incompatibility issue because httpbin imports a class called 'BaseResponse' from the werkzeug library. Werkzeug recently released a new version (2.1.0) removing this class because it's deprecated. Adding the condition `werkzeug < 2.1.0` in the tests/requierements.txt file will temporarly solve the problem.
I requested a PR in the httpbin library, but this little modification will avoid issues in the workflow.
