### PR TITLE
Fix test_follow_link_ua to work with newer httpbin

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -531,7 +531,7 @@ def test_follow_link_ua(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
     # html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
     # browser.open_fake_page(html, httpbin.url)
-    browser.open(httpbin.url)
+    open_legacy_httpbin(browser, httpbin)
     bs4_kwargs = {'url_regex': 'user-agent'}
     requests_kwargs = {'headers': {"User-Agent": '007'}}
     resp = browser.follow_link(bs4_kwargs=bs4_kwargs,


### PR DESCRIPTION
Use the compatibility function open_legacy_httpbin in test_follow_link_ua so that it works with newer versions of httpbin.