### PR TITLE
tests/requirements.txt: pin to flake8 < 5.0.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+flake8 < 5.0.0
 pytest >= 3.1.0
 pytest-cov
 pytest-flake8


### PR DESCRIPTION
The 5.0.0 release of flake8 is incompatible with the most recent version of the pytest-flake8 plugin. Pin to an earlier version until a fix is released.

See https://github.com/tholo/pytest-flake8/issues/87.