### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,15 @@ from setuptools import setup  # Always prefer setuptools over distutils
 
 def requirements_from_file(filename):
     """Parses a pip requirements file into a list."""
-    return [line.strip() for line in open(filename, 'r')
-            if line.strip() and not line.strip().startswith('--')]
+    with open(filename, 'r') as fid:
+        return [line.strip() for line in fid
+                if line.strip() and not line.strip().startswith('--')]
 
 
 def read(fname, URL, URLImage):
     """Read the content of a file."""
-    readme = open(path.join(path.dirname(__file__), fname)).read()
+    with open(path.join(path.dirname(__file__), fname)) as fid:
+        readme = fid.read()
     if hasattr(readme, 'decode'):
         # In Python 3, turn bytes into str.
         readme = readme.decode('utf8')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -262,7 +262,7 @@ def test_no_404(httpbin):
 def test_404(httpbin):
     browser = mechanicalsoup.Browser(raise_on_404=True)
     with pytest.raises(mechanicalsoup.LinkNotFoundError):
-        resp = browser.get(httpbin + "/nosuchpage")
+        browser.get(httpbin + "/nosuchpage")
     resp = browser.get(httpbin.url)
     assert resp.status_code == 200
 

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -89,7 +89,7 @@ def test_no_404(httpbin):
 def test_404(httpbin):
     browser = mechanicalsoup.StatefulBrowser(raise_on_404=True)
     with pytest.raises(mechanicalsoup.LinkNotFoundError):
-        resp = browser.open(httpbin + "/nosuchpage")
+        browser.open(httpbin + "/nosuchpage")
     resp = browser.open(httpbin.url)
     assert resp.status_code == 200
 


### PR DESCRIPTION
* Always use context managers for file resources. Fixes rule py/file-not-closed.

* Don't assign a function return value to a variable when asserting that the function will raise an Exception. Fixes rule py/multiple-definition.