### PR TITLE
Switch Actions from ubuntu-latest to ubuntu-20.04

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The `ubuntu-latest` runner label recently switched from `ubuntu-20.04` to `ubuntu-22.04`. This caused our python 3.6 tests to fail, because the new image only provides python 3.7+.

Having the environment silently change between different Action runs with the same commit is undesirable, so we should select a versioned runner label instead of `ubuntu-latest`. We select `ubuntu-20.04` because we still want to support python 3.6 for now.

See https://github.com/actions/runner-images/issues/6399 for details.