### PR TITLE
Improve test coverage of StatefulBrowser._find_link_internal

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -605,6 +605,15 @@ def test_follow_link_arg(httpbin, expected, kwargs):
     assert browser.url == httpbin + expected
 
 
+def test_follow_link_from_tag():
+    browser = mechanicalsoup.StatefulBrowser()
+    html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
+    browser.open_fake_page(html, httpbin.url)
+    tag = browser.links()[1]
+    browser.follow_link(link=tag)
+    assert browser.url == httpbin + '/get'
+
+
 def test_follow_link_excess(httpbin):
     """Ensure that excess args are passed to BeautifulSoup"""
     browser = mechanicalsoup.StatefulBrowser()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -605,7 +605,7 @@ def test_follow_link_arg(httpbin, expected, kwargs):
     assert browser.url == httpbin + expected
 
 
-def test_follow_link_from_tag():
+def test_follow_link_from_tag(httpbin):
     browser = mechanicalsoup.StatefulBrowser()
     html = '<a href="/foo">Bar</a><a href="/get">Link</a>'
     browser.open_fake_page(html, httpbin.url)


### PR DESCRIPTION
Add a test for when `_find_link_internal` is passed a `bs4.element.Tag` as the `link` argument. Called via `follow_link`.