### PR TITLE
Pin certifi to 2022.12.7 in production requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests >= 2.22.0
 beautifulsoup4 >= 4.7
 lxml
+certifi>=2022.12.7  # not directly required (indirect dependency from requests),
+                    # pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This was done by synk in 914958de0cbc4ce3133a54efc73d2cffc43752bc to avoid vulnerability, but for some reasons it was not done in the main requirements.txt.