### PR TITLE
dev: fix werkzeug vulnerabilities

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,5 @@ pytest-flake8
 pytest-httpbin
 pytest-mock
 requests_mock >= 1.3.0
-werkzeug < 2.1.0
+werkzeug >= 3.0.3
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Pin werkzeug >= 3.0.3 to address all active security vulnerabilities. This is possible now that httpbin has been forked into the PSF org, and a new version has been released (v0.10.0) that is compatible with new werkzeug versions.

Closes #431.