### PR TITLE
Remove support for python 3.6 and 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,8 @@ Release Notes
 Version 1.4 (in development)
 ============================
 
+* Removed support for end of life python versions 3.6 and 3.7.
+
 Version 1.3
 ===========
 

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
These versions reached end of life in Dec 2021 and Jun 2023 respectively. To address recent security vulnerabilities, we need to update to newer versions of dependencies that no longer support these EOL versions (e.g. #434, while this is a dev dependency issue only, it's probably time to update the production requirements as well).