### PR TITLE
Fix codecov uploads after test workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,8 @@ jobs:
       run: coverage xml
 
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true


### PR DESCRIPTION
This change in codecov was due to rate limiting of their global upload token.

Updated to v4 of the codecov action.