### PR TITLE
Update python version support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
 
     license=about['__license__'],
 
-    python_requires='>=3.6',
+    python_requires='>=3.9',
 
     classifiers=[
         'License :: OSI Approved :: MIT License',
@@ -69,10 +69,11 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
     ],
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
-flake8 < 5.0.0
 pytest >= 3.1.0
 pytest-cov
-pytest-flake8
+pytest-flake8 >= 1.3.0
 pytest-httpbin
 pytest-mock
 requests_mock >= 1.3.0


### PR DESCRIPTION
* Remove support for python 3.8 (EOL 2024-10-07)
* Add support for python 3.12 and 3.13

There is a new maintainer for pytest-flake8 (see
https://github.com/tholo/pytest-flake8/issues/98), which allows us to migrate to the newest version of flake8.