### PR TITLE
Refactor form submission

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -181,16 +181,15 @@ class Browser:
         return request_kwargs
 
     @classmethod
-    def get_request_kwargs(cls, form, url=None, **kwargs):
+    def get_request_kwargs(cls, form, url=None, submit=None, **kwargs):
         """Extract input data from the form."""
         method = str(form.get("method", "get"))
         action = form.get("action")
 
         # If the form has a submit button, use its form action
         # https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#formaction.
-        button_submit_element = form.find("button")
-        if button_submit_element:
-            action = button_submit_element.get("formaction", action)
+        if isinstance(submit, bs4.element.Tag) and (submit.name == "button"):
+            action = submit.get("formaction", action)
 
         url = urllib.parse.urljoin(url, action)
         if url is None:  # This happens when both `action` and `url` are None.
@@ -213,6 +212,7 @@ class Browser:
         # skipping those tags that do not have a name-attribute.
         selector = ",".join(f"{tag}[name]" for tag in
                             ("input", "button", "textarea", "select"))
+        submit_added = False
         for tag in form.select(selector):
             name = tag.get("name")  # name-attribute of tag
 
@@ -221,7 +221,15 @@ class Browser:
                 continue
 
             if tag.name == "input":
-                if tag.get("type", "").lower() in ("radio", "checkbox"):
+                tag_type = tag.get("type", "").lower()
+                if tag_type == "submit":
+                    # Skip submit-type inputs that were not selected
+                    if submit_added or (tag != submit):
+                        continue
+                    # Avoid duplicate submits
+                    submit_added = True
+
+                if tag_type in ("radio", "checkbox"):
                     if "checked" not in tag.attrs:
                         continue
                     value = tag.get("value", "on")
@@ -248,10 +256,11 @@ class Browser:
                     data.append((name, value))
 
             elif tag.name == "button":
-                if tag.get("type", "").lower() in ("button", "reset"):
+                # Buttons are only included if they are the selected submit
+                if submit_added or (tag != submit):
                     continue
-                else:
-                    data.append((name, tag.get("value", "")))
+                submit_added = True
+                data.append((name, tag.get("value", "")))
 
             elif tag.name == "textarea":
                 data.append((name, tag.text))
@@ -297,12 +306,12 @@ class Browser:
 
         return cls._get_request_kwargs(method, url, files=files, **kwargs)
 
-    def _request(self, form, url=None, **kwargs):
+    def _request(self, form, url=None, submit=None, **kwargs):
         """Extract input data from the form to pass to a Requests session."""
-        request_kwargs = Browser.get_request_kwargs(form, url, **kwargs)
+        request_kwargs = self.get_request_kwargs(form, url, submit, **kwargs)
         return self.session.request(**request_kwargs)
 
-    def submit(self, form, url=None, **kwargs):
+    def submit(self, form, url=None, btnName=None, **kwargs):
         """Prepares and sends a form request.
 
         NOTE: To submit a form with a :class:`StatefulBrowser` instance, it is
@@ -312,6 +321,9 @@ class Browser:
         :param form: The filled-out form.
         :param url: URL of the page the form is on. If the form action is a
             relative path, then this must be specified.
+        :param btnName: Passed to :func:`Form.choose_submit` to choose the
+            element of the form to use for submission. If not ``None``, will
+            override any existing chosen submit in the form.
         :param \\*\\*kwargs: Arguments forwarded to `requests.Session.request
             <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
             If `files`, `params` (with GET), or `data` (with POST) are
@@ -321,9 +333,13 @@ class Browser:
             <http://docs.python-requests.org/en/master/api/#requests.Response>`__
             object with a *soup*-attribute added by :func:`add_soup`.
         """
-        if isinstance(form, Form):
-            form = form.form
-        response = self._request(form, url, **kwargs)
+        if not isinstance(form, Form):
+            form = Form(form)
+        submit = form.submit_chosen
+        if (submit is None) or (btnName is not None):
+            submit = form.choose_submit(btnName)
+
+        response = self._request(form.form, url, submit, **kwargs)
         Browser.add_soup(response, self.soup_config)
         return response
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -83,8 +83,9 @@ def test_get_request_kwargs_when_submit_element_has_formaction_attribute():
         </form>
     """
     form = BeautifulSoup(form_html, "lxml").form
+    submit = form.button
     request_kwargs = mechanicalsoup.Browser.get_request_kwargs(
-        form, "https://example.com"
+        form, "https://example.com", submit
     )
     assert request_kwargs["url"] == "https://example.com/submit1"
 
@@ -97,18 +98,10 @@ def test_get_request_kwargs_many_submit_elements_have_formaction_attribute():
             <button formaction="https://example.com/submit3"></button>
         </form>
     """
-    browser = mechanicalsoup.StatefulBrowser()
-    browser.open_fake_page(form_html, url="https://example.com")
-    browser.select_form()
-    chosen_button = browser.form.form.find_all(
-        "button"
-    )[1]  # Choose the second button
-    browser.form.choose_submit(
-        submit=chosen_button
-    )
-    assert len(browser.form.form.find_all("button")) == 1
+    form = BeautifulSoup(form_html, "lxml").form
+    submit = form.find_all("button")[1]  # Choose the second button
     request_kwargs = mechanicalsoup.Browser.get_request_kwargs(
-        browser.form.form, "https://example.com"
+        form, "https://example.com", submit
     )
     assert request_kwargs["url"] == "https://example.com/submit2"
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -100,7 +100,8 @@ def test_choose_submit(expected_post):
     form = browser.select_form('#choose-submit-form')
     browser['text'] = dict(expected_post)['text']
     browser['comment'] = dict(expected_post)['comment']
-    form.choose_submit(expected_post[2][0])
+    submit = form.choose_submit(expected_post[2][0])
+    assert submit == form.submit_chosen
     res = browser.submit_selected()
     assert res.status_code == 200 and res.text == 'Success!'
 
@@ -147,11 +148,11 @@ def test_choose_submit_fail(select_name):
         with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
             form.choose_submit(select_name['name'])
     else:
-        form.choose_submit(select_name['name'])
+        assert form.form.input == form.choose_submit(select_name['name'])
 
 
 def test_choose_submit_twice():
-    """Test that calling choose_submit twice fails."""
+    """Test that choose_submit can be used multiple times."""
     text = '''
     <form>
       <input type="submit" name="test1" value="Test1" />
@@ -160,10 +161,9 @@ def test_choose_submit_twice():
     '''
     soup = bs4.BeautifulSoup(text, 'lxml')
     form = mechanicalsoup.Form(soup.form)
-    form.choose_submit('test1')
-    expected_msg = 'Submit already chosen. Cannot change submit!'
-    with pytest.raises(Exception, match=expected_msg):
-        form.choose_submit('test2')
+    test1 = form.choose_submit('test1')
+    test2 = form.choose_submit('test2')
+    assert test1 != test2
 
 
 choose_submit_multiple_match_form = '''

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -891,5 +891,14 @@ def test_requests_session_and_cookies(httpbin):
     assert resp.json() == {'cookies': {'key1': 'val1'}}
 
 
+def test_submit_error():
+    """Check that we are prevented from directly calling the submit method."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page('<form></form>')
+    browser.select_form()
+    with pytest.raises(UserWarning, match="To submit a form"):
+        browser.submit(browser.form)
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)


### PR DESCRIPTION
The `Form.choose_submit` method is no longer destructive, and instead of removing unselected inputs, it simply stores (and returns) which submit was chosen. This allows the `Form` object to be reused for multiple form submissions, and thus the logic for extracting the input data from the form is fully encapsulated in `Browser.get_request_kwargs`.

Previously, `Browser.get_request_kwargs` assumed that the form data was already processed (e.g. so that there was only one submit/button input), which could result in a malformed request if this was not done by, e.g., calling `Browser.submit` directly. It now has an optional `submit` argument and can correctly process the raw form that may have multiple submit/button inputs.

We add a `StatefulBrowser.submit` method override that only raises an Exception to prevent calling the `Browser.submit` method directly on a StatefulBrowser object. This is an important restriction, because it could be confused with the recommended `StatefulBrowser.submit_selected` method. If needed for some arcane reason, you can pass a StatefulBrowser object into the `Browser.submit` function to recover this behavior.

To ensure that form submission is valid whether we call `Browser.submit` or `StatefulBrowser.submit_selected`, the `Form.choose_submit` call has been moved into `Browser.submit`, which now has a `btnName` argument so that the same argument from `StatefulBrowser.submit_selected` can be passed in.

Please note that `StatefulBrowser.submit_selected` will now override a previously chosen submit instead of raising an Exception if `btnName` is specified after calling `Form.choose_submit` (or an earlier call to `StatefulBrowser.submit_selected` on the same page, which was previously not possible).

Closes #233 (superseded).
Fixes #230.