### PR TITLE
Add Form.__getitem__, __iter__, and keys() methods

### DIFF
--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -241,6 +241,88 @@ class Form:
         """
         return self.set(name, value)
 
+    def __getitem__(self, name):
+        """Get the current value of the named form field.
+
+        Returns the value that would be submitted for the given field.
+        For checkboxes, returns a list of checked values.
+        For radio buttons, returns the selected value or ``None`` if none
+        is selected.
+        Raises ``KeyError`` if no field with the given name exists.
+
+        Example: ::
+
+            browser.select_form()
+            browser["username"] = "ada"
+            assert browser.form["username"] == "ada"
+        """
+        # Case-insensitive search for type=checkbox
+        checkboxes = self.form.select(f'input[type="checkbox" i][name="{name}"]')
+        if checkboxes:
+            return [cb.get("value", "on") for cb in checkboxes if "checked" in cb.attrs]
+
+        # Case-insensitive search for type=radio
+        radios = self.form.select(f'input[type="radio" i][name="{name}"]')
+        if radios:
+            for r in radios:
+                if "checked" in r.attrs:
+                    return r.get("value", "on")
+            return None
+
+        # Regular input (text, password, hidden, email, etc.)
+        inp = self.form.find("input", {"name": name})
+        if inp:
+            return inp.get("value", "")
+
+        # Select element
+        select = self.form.find("select", {"name": name})
+        if select:
+            if "multiple" in select.attrs:
+                return [
+                    o.get("value", o.get_text())
+                    for o in select.find_all("option")
+                    if "selected" in o.attrs
+                ]
+            selected = select.find("option", attrs={"selected": True})
+            if not selected:
+                selected = select.find("option")  # first option is the default
+            return selected.get("value", selected.get_text().strip()) if selected else ""
+
+        # Textarea element
+        ta = self.form.find("textarea", {"name": name})
+        if ta:
+            return ta.string or ""
+
+        raise KeyError(f"No field named: {name}")
+
+    def __iter__(self):
+        """Iterate over the names of all named fields in the form.
+
+        Yields each unique field name once, in document order.
+
+        Example: ::
+
+            field_names = list(form)
+        """
+        seen = set()
+        for el in self.form.find_all(["input", "select", "textarea"]):
+            name = el.get("name")
+            if name and name not in seen:
+                seen.add(name)
+                yield name
+
+    def keys(self):
+        """Return the names of all named fields in the form.
+
+        Returns a list of unique field names, in document order.
+
+        Example: ::
+
+            if "username" in form.keys():
+                form["username"] = "ada"
+        """
+        return list(self.__iter__())
+
     def set(self, name, value, force=False):
         """Set a form element identified by ``name`` to a specified ``value``.
         The type of element (input, textarea, select, ...) does not

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -257,12 +257,22 @@ class Form:
             assert browser.form["username"] == "ada"
         """
         # Case-insensitive search for type=checkbox
-        checkboxes = self.form.select(f'input[type="checkbox" i][name="{name}"]')
+        selector = (
+            f'input[type="checkbox" i][name="{name}"]'
+        )
+        checkboxes = self.form.select(selector)
         if checkboxes:
-            return [cb.get("value", "on") for cb in checkboxes if "checked" in cb.attrs]
+            return [
+                cb.get("value", "on")
+                for cb in checkboxes
+                if "checked" in cb.attrs
+            ]
 
         # Case-insensitive search for type=radio
-        radios = self.form.select(f'input[type="radio" i][name="{name}"]')
+        selector = (
+            f'input[type="radio" i][name="{name}"]'
+        )
+        radios = self.form.select(selector)
         if radios:
             for r in radios:
                 if "checked" in r.attrs:
@@ -286,7 +296,11 @@ class Form:
             selected = select.find("option", attrs={"selected": True})
             if not selected:
                 selected = select.find("option")  # first option is the default
-            return selected.get("value", selected.get_text().strip()) if selected else ""
+            if not selected:
+                return ""
+            return selected.get(
+                "value", selected.get_text().strip()
+            )
 
         # Textarea element
         ta = self.form.find("textarea", {"name": name})

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -548,5 +548,138 @@ def test_option_without_value(fail, selected, expected_post):
         assert res.status_code == 200 and res.text == 'Success!'
 
 
+getitem_form = '''
+<html>
+  <body>
+    <form id="getitem-form" method="post" action="mock://form.com/post">
+      <input type="text" name="username" value="ada" />
+      <input type="password" name="password" value="secret" />
+      <input type="hidden" name="token" value="abc123" />
+      <input type="checkbox" name="color" value="red" checked />
+      <input type="checkbox" name="color" value="blue" />
+      <input type="checkbox" name="color" value="green" checked />
+      <input type="radio" name="size" value="small" />
+      <input type="radio" name="size" value="medium" checked />
+      <input type="radio" name="size" value="large" />
+      <input type="radio" name="unset_radio" value="a" />
+      <select name="country">
+        <option value="us">United States</option>
+        <option value="uk" selected>United Kingdom</option>
+        <option value="de">Germany</option>
+      </select>
+      <select name="langs" multiple>
+        <option value="py" selected>Python</option>
+        <option value="js">JavaScript</option>
+        <option value="rs" selected>Rust</option>
+      </select>
+      <textarea name="bio">Hello world</textarea>
+      <input type="submit" value="Go" />
+    </form>
+  </body>
+</html>
+'''
+
+
+def test_form_getitem_text_inputs():
+    """__getitem__ returns text/password/hidden input values."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["username"] == "ada"
+    assert form["password"] == "secret"
+    assert form["token"] == "abc123"
+
+
+def test_form_getitem_checkbox():
+    """__getitem__ returns a list of checked checkbox values."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["color"] == ["red", "green"]
+
+
+def test_form_getitem_radio():
+    """__getitem__ returns the selected radio value."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["size"] == "medium"
+
+
+def test_form_getitem_radio_none_selected():
+    """__getitem__ returns None when no radio button is checked."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["unset_radio"] is None
+
+
+def test_form_getitem_select():
+    """__getitem__ returns the selected option value for a single select."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["country"] == "uk"
+
+
+def test_form_getitem_select_multiple():
+    """__getitem__ returns a list of selected option values for a multi-select."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["langs"] == ["py", "rs"]
+
+
+def test_form_getitem_textarea():
+    """__getitem__ returns the current textarea content."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert form["bio"] == "Hello world"
+
+
+def test_form_getitem_keyerror():
+    """__getitem__ raises KeyError for unknown field names."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    with pytest.raises(KeyError):
+        _ = form["nonexistent"]
+
+
+def test_form_getitem_reflects_setitem():
+    """After __setitem__, __getitem__ returns the updated value."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    form["username"] = "bob"
+    assert form["username"] == "bob"
+
+
+def test_form_keys():
+    """keys() returns all unique named field names in document order."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    k = form.keys()
+    assert isinstance(k, list)
+    # All named fields are present
+    for name in ("username", "password", "token", "color", "size",
+                 "unset_radio", "country", "langs", "bio"):
+        assert name in k
+    # Each name appears only once
+    assert len(k) == len(set(k))
+    # Document order: username before password before token
+    assert k.index("username") < k.index("password") < k.index("token")
+
+
+def test_form_iter():
+    """__iter__ yields the same names as keys()."""
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(getitem_form)
+    form = browser.select_form('#getitem-form')
+    assert list(form) == form.keys()
+
+
 if __name__ == '__main__':
     pytest.main(sys.argv)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -622,8 +622,27 @@ def test_form_getitem_select():
     assert form["country"] == "uk"
 
 
+def test_form_getitem_select_default():
+    """__getitem__ returns the first option when none is selected."""
+    html = '''
+    <html><body>
+    <form id="f" method="post" action="mock://form.com/post">
+      <select name="fruit">
+        <option value="apple">Apple</option>
+        <option value="banana">Banana</option>
+      </select>
+    </form>
+    </body></html>
+    '''
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(html)
+    form = browser.select_form('#f')
+    assert form["fruit"] == "apple"
+
+
 def test_form_getitem_select_multiple():
-    """__getitem__ returns a list of selected option values for a multi-select."""
+    """__getitem__ returns a list of selected values
+    for a multi-select."""
     browser = mechanicalsoup.StatefulBrowser()
     browser.open_fake_page(getitem_form)
     form = browser.select_form('#getitem-form')


### PR DESCRIPTION
Fixes #444.

`Form.__setitem__` allowed setting values by name, but there was no way to read them back. This adds:

**`__getitem__(name)`** - returns the current field value:
- Text/password/hidden inputs: the `value` attribute.
- Checkboxes: a list of checked values.
- Radio buttons: the selected value, or `None` if none is selected.
- Single `<select>`: the selected option value.
- `<select multiple>`: a list of selected option values.
- `<textarea>`: the text content.
- Raises `KeyError` if the field does not exist.

**`__iter__()`** - yields unique field names in document order.

**`keys()`** - returns a list of unique field names in document order.

Example:
```python
browser.select_form()
browser["size"] = "medium"
assert browser.form["size"] == "medium"
assert "size" in browser.form.keys()
```

Tests for all cases are added in `tests/test_form.py`.