### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,5 @@
+cff-version: 1.2.0
+title: "MechanicalSoup"
+authors:
+  - name: "MechanicalSoup developers"
+url: "https://github.com/MechanicalSoup/MechanicalSoup"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,11 @@
 cff-version: 1.2.0
 title: "MechanicalSoup"
 authors:
-  - name: "MechanicalSoup developers"
+  - family-names: "Moy"
+    given-names: "Matthieu"
+    orcid: "https://orcid.org/0000-0002-6054-8882"
+  - family-names: "Hemberger"
+    given-names: "Daniel"
+    orcid: "https://orcid.org/0009-0001-0545-5448"
+  - name: "MechanicalSoup contributors"
 url: "https://github.com/MechanicalSoup/MechanicalSoup"


### PR DESCRIPTION
This file will help users cite MechanicalSoup. CFF is a standard format that is supported by GitHub.

Closes #469.

@moy If you have an ORCID ID and would like me to add you by name to the authors list here, just let me know or feel free to change it yourself. Thanks :)