### PR TITLE
docs: explain valid features values for soup_config parameter

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -174,7 +174,7 @@ to use, like::
 Or if you don't have the parser `lxml
 <http://lxml.de/installation.html>`__ installed::
 
-    mechanicalsoup.StatefulBrowser(soup_config={'features': 'parser.html', ...})
+    mechanicalsoup.StatefulBrowser(soup_config={'features': 'html.parser', ...})
 
 See also
 https://www.crummy.com/software/BeautifulSoup/bs4/doc/#you-need-a-parser

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -22,13 +22,15 @@ class Browser:
 
     :param session: Attach a pre-existing requests Session instead of
         constructing a new one.
-    :param soup_config: Configuration passed to BeautifulSoup to affect
-        the way HTML is parsed. Defaults to ``{'features': 'lxml'}``.
-        If overridden, it is highly recommended to `specify a parser
-        <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use>`__.
-        Otherwise, BeautifulSoup will issue a warning and pick one for
-        you, but the parser it chooses may be different on different
-        machines.
+    :param soup_config: Configuration passed as keyword arguments to
+        ``bs4.BeautifulSoup`` to affect the way HTML is parsed. The
+        ``features`` key specifies the parser to use. Valid values include
+        ``"lxml"``, ``"lxml-xml"``, ``"html.parser"``, ``"html5lib"``,
+        or a markup type (``"html"``, ``"html5"``, ``"xml"``). It is
+        recommended to name a specific parser for consistent behavior
+        across platforms. See the `BeautifulSoup parser docs
+        <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use>`__
+        for more details. Defaults to ``{'features': 'lxml'}``.
     :param requests_adapters: Configuration passed to requests, to affect
         the way HTTP requests are performed.
     :param raise_on_404: If True, raise :class:`LinkNotFoundError`

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -26,13 +26,15 @@ class StatefulBrowser(Browser):
 
     :param session: Attach a pre-existing requests Session instead of
         constructing a new one.
-    :param soup_config: Configuration passed to BeautifulSoup to affect
-        the way HTML is parsed. Defaults to ``{'features': 'lxml'}``.
-        If overridden, it is highly recommended to `specify a parser
-        <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use>`__.
-        Otherwise, BeautifulSoup will issue a warning and pick one for
-        you, but the parser it chooses may be different on different
-        machines.
+    :param soup_config: Configuration passed as keyword arguments to
+        ``bs4.BeautifulSoup`` to affect the way HTML is parsed. The
+        ``features`` key specifies the parser to use. Valid values include
+        ``"lxml"``, ``"lxml-xml"``, ``"html.parser"``, ``"html5lib"``,
+        or a markup type (``"html"``, ``"html5"``, ``"xml"``). It is
+        recommended to name a specific parser for consistent behavior
+        across platforms. See the `BeautifulSoup parser docs
+        <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use>`__
+        for more details. Defaults to ``{'features': 'lxml'}``.
     :param requests_adapters: Configuration passed to requests, to affect
         the way HTTP requests are performed.
     :param raise_on_404: If True, raise :class:`LinkNotFoundError`


### PR DESCRIPTION
## Description

The `soup_config` parameter documentation was vague about what values the `features` key accepts. This change explicitly lists valid parser names (`lxml`, `lxml-xml`, `html.parser`, `html5lib`) and markup types (`html`, `html5`, `xml`) for both `Browser` and `StatefulBrowser`. Also fixes the incorrect parser name `parser.html` → `html.parser` in the FAQ.

## Changes

- `mechanicalsoup/browser.py`: Updated `soup_config` parameter docstring
- `mechanicalsoup/stateful_browser.py`: Updated `soup_config` parameter docstring
- `docs/faq.rst`: Fixed parser name in example

## Type of Change
- [x] Documentation

## Related Issue
Fixes #433