### PR TITLE
Restrict to pytest < 9.1 due to pytest-flake8 limitation

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
-pytest >= 3.1.0
+pytest >= 3.1.0, < 9.1 # upper limit needed until pytest-flake8 is updated
+                       # (see https://github.com/coherent-oss/pytest-flake8/issues/5)
 pytest-cov
 pytest-flake8 >= 1.3.0
 pytest-httpbin


### PR DESCRIPTION
The pytest-flake8 plugin is using an API that was removed in pytest 9.1. This makes it incompatible with newer versions of pytest. Pin pytest to an older version until the incompatibility is addressed (or until we switch to an alternative, e.g. pylint/ruff).

See https://github.com/coherent-oss/pytest-flake8/issues/5.