### PR TITLE
Add return typehint for ResponseWithSoup objects

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -53,3 +52,14 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
+
+  mypy:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install mypy -r requirements.txt
+      - name: Run mypy
+        run: mypy mechanicalsoup

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,6 +60,6 @@ jobs:
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip
-            python -m pip install mypy -r requirements.txt
+            python -m pip install -r requirements.txt -r tests/requirements.txt
       - name: Run mypy
         run: mypy mechanicalsoup

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -1,6 +1,7 @@
 import io
 import os
 import tempfile
+from typing import cast
 import urllib
 import weakref
 import webbrowser
@@ -12,6 +13,10 @@ import requests
 from .__version__ import __title__, __version__
 from .form import Form
 from .utils import LinkNotFoundError, is_disabled, is_multipart_file_upload
+
+
+class ResponseWithSoup(requests.Response):
+    soup: bs4.BeautifulSoup | None
 
 
 class Browser:
@@ -36,10 +41,14 @@ class Browser:
     :param user_agent: Set the user agent header to this value.
 
     """
-    def __init__(self, session=None, soup_config=(('features', 'lxml'),),
-                 requests_adapters=None,
-                 raise_on_404=False, user_agent=None):
-
+    def __init__(
+        self,
+        session: requests.Session | None = None,
+        soup_config=(('features', 'lxml'),),
+        requests_adapters=None,
+        raise_on_404=False,
+        user_agent=None,
+    ):
         self.raise_on_404 = raise_on_404
         self.session = session or requests.Session()
 
@@ -54,7 +63,7 @@ class Browser:
         self.soup_config = dict(soup_config or ())
 
     @staticmethod
-    def __looks_like_html(response):
+    def __looks_like_html(response: requests.Response) -> bool:
         """Guesses entity type when Content-Type header is missing.
         Since Content-Type is not strictly required, some servers leave it out.
         """
@@ -62,8 +71,10 @@ class Browser:
         return text.startswith('<html') or text.startswith('<!doctype')
 
     @staticmethod
-    def add_soup(response, soup_config):
+    def add_soup(response: requests.Response, soup_config) -> ResponseWithSoup:
         """Attaches a soup object to a requests response."""
+        response.__class__ = ResponseWithSoup
+        response = cast(ResponseWithSoup, response)
         if ("text/html" in response.headers.get("Content-Type", "") or
                 Browser.__looks_like_html(response)):
             # Note: By default (no charset provided in HTTP headers), requests
@@ -90,6 +101,7 @@ class Browser:
             )
         else:
             response.soup = None
+        return response
 
     def set_cookiejar(self, cookiejar):
         """Replaces the current cookiejar in the requests session. Since the
@@ -116,7 +128,7 @@ class Browser:
         # the requests module uses a case-insensitive dict for session headers
         self.session.headers['User-agent'] = user_agent
 
-    def request(self, *args, **kwargs):
+    def request(self, *args, **kwargs) -> ResponseWithSoup:
         """Straightforward wrapper around `requests.Session.request
         <http://docs.python-requests.org/en/master/api/#requests.Session.request>`__.
 
@@ -130,10 +142,9 @@ class Browser:
         example.
         """
         response = self.session.request(*args, **kwargs)
-        Browser.add_soup(response, self.soup_config)
-        return response
+        return Browser.add_soup(response, self.soup_config)
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs) -> ResponseWithSoup:
         """Straightforward wrapper around `requests.Session.get
         <http://docs.python-requests.org/en/master/api/#requests.Session.get>`__.
 
@@ -144,10 +155,9 @@ class Browser:
         response = self.session.get(*args, **kwargs)
         if self.raise_on_404 and response.status_code == 404:
             raise LinkNotFoundError()
-        Browser.add_soup(response, self.soup_config)
-        return response
+        return Browser.add_soup(response, self.soup_config)
 
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs) -> ResponseWithSoup:
         """Straightforward wrapper around `requests.Session.post
         <http://docs.python-requests.org/en/master/api/#requests.Session.post>`__.
 
@@ -156,10 +166,9 @@ class Browser:
             object with a *soup*-attribute added by :func:`add_soup`.
         """
         response = self.session.post(*args, **kwargs)
-        Browser.add_soup(response, self.soup_config)
-        return response
+        return Browser.add_soup(response, self.soup_config)
 
-    def put(self, *args, **kwargs):
+    def put(self, *args, **kwargs) -> ResponseWithSoup:
         """Straightforward wrapper around `requests.Session.put
         <http://docs.python-requests.org/en/master/api/#requests.Session.put>`__.
 
@@ -168,8 +177,7 @@ class Browser:
             object with a *soup*-attribute added by :func:`add_soup`.
         """
         response = self.session.put(*args, **kwargs)
-        Browser.add_soup(response, self.soup_config)
-        return response
+        return Browser.add_soup(response, self.soup_config)
 
     @staticmethod
     def _get_request_kwargs(method, url, **kwargs):
@@ -308,12 +316,12 @@ class Browser:
 
         return cls._get_request_kwargs(method, url, files=files, **kwargs)
 
-    def _request(self, form, url=None, submit=None, **kwargs):
+    def _request(self, form, url=None, submit=None, **kwargs) -> requests.Response:
         """Extract input data from the form to pass to a Requests session."""
         request_kwargs = self.get_request_kwargs(form, url, submit, **kwargs)
         return self.session.request(**request_kwargs)
 
-    def submit(self, form, url=None, btnName=None, **kwargs):
+    def submit(self, form, url=None, btnName=None, **kwargs) -> ResponseWithSoup:
         """Prepares and sends a form request.
 
         NOTE: To submit a form with a :class:`StatefulBrowser` instance, it is
@@ -342,8 +350,7 @@ class Browser:
             submit = form.choose_submit(btnName)
 
         response = self._request(form.form, url, submit, **kwargs)
-        Browser.add_soup(response, self.soup_config)
-        return response
+        return Browser.add_soup(response, self.soup_config)
 
     def launch_browser(self, soup):
         """Launch a browser to display a page, for debugging purposes.

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -316,12 +316,24 @@ class Browser:
 
         return cls._get_request_kwargs(method, url, files=files, **kwargs)
 
-    def _request(self, form, url=None, submit=None, **kwargs) -> requests.Response:
+    def _request(
+        self,
+        form,
+        url=None,
+        submit=None,
+        **kwargs,
+    ) -> requests.Response:
         """Extract input data from the form to pass to a Requests session."""
         request_kwargs = self.get_request_kwargs(form, url, submit, **kwargs)
         return self.session.request(**request_kwargs)
 
-    def submit(self, form, url=None, btnName=None, **kwargs) -> ResponseWithSoup:
+    def submit(
+        self,
+        form,
+        url=None,
+        btnName=None,
+        **kwargs,
+    ) -> ResponseWithSoup:
         """Prepares and sends a form request.
 
         NOTE: To submit a form with a :class:`StatefulBrowser` instance, it is

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -272,7 +272,12 @@ class StatefulBrowser(Browser):
             use `Browser.submit(br, ...)` (where `br` is a StatefulBrowser).
         """)
 
-    def submit_selected(self, btnName=None, update_state=True, **kwargs) -> ResponseWithSoup:
+    def submit_selected(
+        self,
+        btnName=None,
+        update_state=True,
+        **kwargs,
+    ) -> ResponseWithSoup:
         """Submit the form that was selected with :func:`select_form`.
 
         :return: Forwarded from :func:`Browser.submit`.

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -3,8 +3,9 @@ import sys
 import urllib
 
 import bs4
+import requests
 
-from .browser import Browser
+from .browser import Browser, ResponseWithSoup
 from .form import Form
 from .utils import LinkNotFoundError
 
@@ -133,7 +134,7 @@ class StatefulBrowser(Browser):
         """
         return urllib.parse.urljoin(self.url, url)
 
-    def open(self, url, *args, **kwargs):
+    def open(self, url, *args, **kwargs) -> ResponseWithSoup:
         """Open the URL and store the Browser's state in this object.
         All arguments are forwarded to :func:`Browser.get`.
 
@@ -162,13 +163,13 @@ class StatefulBrowser(Browser):
             page=bs4.BeautifulSoup(page_text, **soup_config),
             url=url)
 
-    def open_relative(self, url, *args, **kwargs):
+    def open_relative(self, url, *args, **kwargs) -> ResponseWithSoup:
         """Like :func:`open`, but ``url`` can be relative to the currently
         visited page.
         """
         return self.open(self.absolute_url(url), *args, **kwargs)
 
-    def refresh(self):
+    def refresh(self) -> ResponseWithSoup:
         """Reload the current page with the same request as originally done.
         Any change (`select_form`, or any value filled-in in the form) made to
         the current page before refresh is discarded.
@@ -184,7 +185,7 @@ class StatefulBrowser(Browser):
                              'were used to do so')
 
         resp = self.session.send(old_request)
-        Browser.add_soup(resp, self.soup_config)
+        resp = Browser.add_soup(resp, self.soup_config)
         self.__state = _BrowserState(page=resp.soup, url=resp.url,
                                      request=resp.request)
         return resp
@@ -271,7 +272,7 @@ class StatefulBrowser(Browser):
             use `Browser.submit(br, ...)` (where `br` is a StatefulBrowser).
         """)
 
-    def submit_selected(self, btnName=None, update_state=True, **kwargs):
+    def submit_selected(self, btnName=None, update_state=True, **kwargs) -> ResponseWithSoup:
         """Submit the form that was selected with :func:`select_form`.
 
         :return: Forwarded from :func:`Browser.submit`.
@@ -371,7 +372,7 @@ class StatefulBrowser(Browser):
             raise
 
     def follow_link(self, link=None, *bs4_args, bs4_kwargs=(),
-                    requests_kwargs=(),  **kwargs):
+                    requests_kwargs=(),  **kwargs) -> ResponseWithSoup:
         """Follow a link.
 
         If ``link`` is a bs4.element.Tag (i.e. from a previous call to
@@ -403,7 +404,7 @@ class StatefulBrowser(Browser):
         return self.open_relative(link['href'], **requests_kwargs)
 
     def download_link(self, link=None, file=None, *bs4_args, bs4_kwargs=(),
-                      requests_kwargs=(), **kwargs):
+                      requests_kwargs=(), **kwargs) -> requests.Response:
         """Downloads the contents of a link to a file. This function behaves
         similarly to :func:`follow_link`, but the browser state will
         not change when calling this function.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+mypy
 pytest >= 3.1.0, < 9.1 # upper limit needed until pytest-flake8 is updated
                        # (see https://github.com/coherent-oss/pytest-flake8/issues/5)
 pytest-cov
@@ -5,6 +6,7 @@ pytest-flake8 >= 1.3.0
 pytest-httpbin
 pytest-mock
 requests_mock >= 1.3.0
+types-requests
 werkzeug >= 3.0.3
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Begin to add typehint infrastructure by solving the biggest limiting factor: mutating the type of the Response object returned by requests. While it may be better to use an intersection between a Response object and a Protocol that has a `soup` attribute, intersection is not yet well-supported in the typing ecosystem. Instead, use a class derived from the requests Response object that contains a `soup` attribute and explicitly mutate the type in the `add_soup` method.

Add a mypy GitHub Actions test to validate any types that we specify.