### PR TITLE
Do not submit controls inside a disabled <fieldset>

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,10 @@ Release Notes
 Version 1.5 (in development)
 ============================
 
+* Form controls inside a disabled ``<fieldset>`` are no longer submitted,
+  matching browser behavior and the HTML specification. Controls inside the
+  fieldset's first ``<legend>`` remain enabled.
+
 Version 1.4
 ===========
 

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -11,7 +11,7 @@ import requests
 
 from .__version__ import __title__, __version__
 from .form import Form
-from .utils import LinkNotFoundError, is_multipart_file_upload
+from .utils import LinkNotFoundError, is_disabled, is_multipart_file_upload
 
 
 class Browser:
@@ -217,7 +217,9 @@ class Browser:
             name = tag.get("name")  # name-attribute of tag
 
             # Skip disabled elements, since they should not be submitted.
-            if tag.has_attr('disabled'):
+            # A control is also disabled when it descends from a disabled
+            # <fieldset> (outside that fieldset's first <legend>).
+            if is_disabled(tag):
                 continue
 
             if tag.name == "input":

--- a/mechanicalsoup/utils.py
+++ b/mechanicalsoup/utils.py
@@ -21,3 +21,28 @@ def is_multipart_file_upload(form, tag):
         form.get("enctype", "") == "multipart/form-data" and
         tag.get("type", "").lower() == "file"
     )
+
+
+def is_disabled(tag):
+    """Return whether a form control is disabled per the HTML specification.
+
+    A control is disabled if it carries a ``disabled`` attribute, or if it is
+    a descendant of a ``<fieldset>`` element whose ``disabled`` attribute is
+    set -- except when it is inside that fieldset's first ``<legend>`` child,
+    which stays enabled. Disabled controls are barred from submission, so
+    browsers do not include their name/value pairs in the form data.
+
+    https://html.spec.whatwg.org/multipage/form-elements.html#concept-fieldset-disabled
+    """
+    if tag.has_attr("disabled"):
+        return True
+    for fieldset in tag.find_parents("fieldset"):
+        if not fieldset.has_attr("disabled"):
+            continue
+        # Controls inside the disabled fieldset's first <legend> child are
+        # not disabled by that fieldset.
+        legend = fieldset.find("legend", recursive=False)
+        if legend is not None and any(p is legend for p in tag.parents):
+            continue
+        return True
+    return False

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -277,6 +277,35 @@ def test__request_disabled_attr(httpbin):
     assert response.json()['form'] == {}
 
 
+def test__request_disabled_fieldset(httpbin):
+    """Controls inside a disabled <fieldset> must not be submitted, but the
+    fieldset's first <legend> stays enabled (per the HTML specification)."""
+    form_html = f"""
+    <form method="post" action="{httpbin.url}/post">
+      <input name="enabled" value="1" />
+      <fieldset disabled>
+        <legend>
+          <input name="in_legend" value="legend" />
+        </legend>
+        <input name="text" value="2" />
+        <input type="checkbox" name="check" value="on" checked />
+        <select name="sel"><option value="x" selected>x</option></select>
+        <textarea name="area">hi</textarea>
+        <button name="btn" value="go">Go</button>
+        <fieldset>
+          <input name="nested" value="3" />
+        </fieldset>
+      </fieldset>
+    </form>"""
+
+    browser = mechanicalsoup.Browser()
+    response = browser._request(BeautifulSoup(form_html, "lxml").form)
+    # Only the control outside the fieldset and the one in its first <legend>
+    # are submitted; everything else in the disabled fieldset (including a
+    # nested, non-disabled fieldset) is omitted.
+    assert response.json()['form'] == {'enabled': '1', 'in_legend': 'legend'}
+
+
 @pytest.mark.parametrize("keyword", [
     pytest.param('method'),
     pytest.param('url'),


### PR DESCRIPTION
## Problem

`Browser.get_request_kwargs` skips a form control from submission only when the
control carries its own `disabled` attribute:

```python
if tag.has_attr('disabled'):
    continue
```

Per the [HTML specification](https://html.spec.whatwg.org/multipage/form-elements.html#concept-fieldset-disabled),
a control is *also* disabled when it descends from a `<fieldset>` whose
`disabled` attribute is set — except when it is inside that fieldset's first
`<legend>`, which stays enabled — and disabled controls are barred from
submission. MechanicalSoup, which aims for browser fidelity, submitted them
anyway.

Given a form with a `<fieldset disabled>`, a real browser submits only the
controls outside the fieldset (and those in its first `<legend>`), whereas
MechanicalSoup submitted every control:

```python
# emitted: {'enabled': '1', 'in_legend': 'legend', 'text': '2',
#           'check': 'on', 'sel': 'x', 'area': 'hi', 'nested': '3'}
# browser: {'enabled': '1', 'in_legend': 'legend'}
```

## Fix

Add an `is_disabled(tag)` helper that returns `True` for a control with its own
`disabled` attribute *or* one descending from a disabled ancestor `<fieldset>`,
honoring the first-`<legend>` exemption and nested-fieldset propagation, and use
it in place of the bare `has_attr('disabled')` check. This extends the existing
disabled-control handling (from #248) rather than changing behavior introduced
by the #461 refactor.

## Tests

`tests/test_browser.py::test__request_disabled_fieldset` builds a form with a
disabled fieldset containing text/checkbox/select/textarea/button controls, a
first `<legend>`, and a nested inner fieldset, then asserts only the controls
outside the fieldset and inside its first `<legend>` are submitted. It fails
before the change and passes after. Full suite passes (124 passed;
`test_launch_browser` errors on pristine HEAD too — an unrelated headless
`webbrowser` launch). `flake8` clean.
