### PR TITLE
Switch GHA tests from PyPy 3.10 to 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11"]
 
     steps:
     - uses: actions/checkout@v7

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,4 +8,3 @@ requests_mock >= 1.3.0
 werkzeug >= 3.0.3
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
-rpds-py<0.28 # not directly required, pinned to support pypy-3.10


### PR DESCRIPTION
This is an attempt to fix #462, because lxml is no longer providing wheels for PyPy-3.10 as of lxml version 6.1. There are wheels for PyPy-3.11, so testing against that should solve the problem.