### PR TITLE
Remove unnecessary "or ()" in handling immutable defaults

### DIFF
--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -392,8 +392,8 @@ class StatefulBrowser(Browser):
 
         :return: Forwarded from :func:`open_relative`.
         """
-        bs4_kwargs = dict(bs4_kwargs or ())
-        requests_kwargs = dict(requests_kwargs or ())
+        bs4_kwargs = dict(bs4_kwargs)
+        requests_kwargs = dict(requests_kwargs)
 
         link = self._find_link_internal(link, bs4_args,
                                         {**bs4_kwargs, **kwargs})
@@ -421,8 +421,8 @@ class StatefulBrowser(Browser):
             <http://docs.python-requests.org/en/master/api/#requests.Response>`__
             object.
         """
-        bs4_kwargs = dict(bs4_kwargs or ())
-        requests_kwargs = dict(requests_kwargs or ())
+        bs4_kwargs = dict(bs4_kwargs)
+        requests_kwargs = dict(requests_kwargs)
 
         link = self._find_link_internal(link, bs4_args,
                                         {**bs4_kwargs, **kwargs})


### PR DESCRIPTION
In these cases, we previously only accepted mapping types, so there's no need to fallback to `dict(())` when the argument is falsy.

This is a followup to #473.