### PR TITLE
Raise an explanatory error from links() when no page is loaded

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -8,6 +8,8 @@ Version 1.5 (in development)
 * Form controls inside a disabled ``<fieldset>`` are no longer submitted,
   matching browser behavior and the HTML specification. Controls inside the
   fieldset's first ``<legend>`` remain enabled.
+* ``StatefulBrowser.links`` now raises an explanatory ``AttributeError`` when
+  no page is loaded, instead of failing inside BeautifulSoup.
 
 Version 1.4
 ===========

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -315,7 +315,14 @@ class StatefulBrowser(Browser):
         *text*-attribute of the Tag. All other arguments are forwarded to
         the `.find_all() method in BeautifulSoup
         <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all>`__.
+
+        If no page is currently loaded, raise :class:`AttributeError`.
         """
+        if self.page is None:
+            raise AttributeError(
+                "No page has been opened yet on this browser, or the last "
+                "response was not parsed as a page (e.g. it was not HTML)."
+            )
         all_links = self.page.find_all(
             'a', href=True, *args, **kwargs)
         if url_regex is not None:

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -143,6 +143,14 @@ def test_links():
     assert two_links == BeautifulSoup(html, "lxml").find_all('a')
 
 
+def test_links_no_page():
+    """links() must report that no page is loaded rather than failing with
+    an opaque AttributeError from the underlying None."""
+    browser = mechanicalsoup.StatefulBrowser()
+    with pytest.raises(AttributeError, match="No page has been opened"):
+        browser.links()
+
+
 @pytest.mark.parametrize("expected_post", [
     pytest.param(
         [


### PR DESCRIPTION
Closes #410

`links()` called `self.page.find_all()` unconditionally, so calling it before any page is opened — or after a response that wasn't parsed as a page (the reporter hit a PDF) — failed with `'NoneType' object has no attribute 'find_all'`, which gives no hint about the real cause.

Per @hemberger's suggestion on the issue, this keeps the exception (rather than returning `[]`, which would be indistinguishable from a page with no links) but makes the message explain the condition, mirroring how the `form` property already reports an unselected form.
