### PR TITLE
Detect HTML from raw leading bytes in __looks_like_html

### DIFF
--- a/docs/ChangeLog.rst
+++ b/docs/ChangeLog.rst
@@ -5,6 +5,11 @@ Release Notes
 Version 1.5 (in development)
 ============================
 
+* When the ``Content-Type`` header is missing, HTML is now detected from the
+  first bytes of the response instead of decoding the whole body, which is
+  much faster for large binary responses. Uppercase markup such as ``<HTML>``
+  is now detected as well.
+
 * Form controls inside a disabled ``<fieldset>`` are no longer submitted,
   matching browser behavior and the HTML specification. Controls inside the
   fieldset's first ``<legend>`` remain enabled.

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -1,5 +1,6 @@
 import io
 import os
+import re
 import tempfile
 import urllib
 import weakref
@@ -53,13 +54,26 @@ class Browser:
 
         self.soup_config = dict(soup_config or ())
 
+    _HTML_MARKER_RE = re.compile(
+        rb'\s*(?:\xef\xbb\xbf|\xff\xfe|\xfe\xff)?\s*(?:<html|<!doctype)',
+        re.IGNORECASE
+    )
+
     @staticmethod
     def __looks_like_html(response):
         """Guesses entity type when Content-Type header is missing.
         Since Content-Type is not strictly required, some servers leave it out.
         """
-        text = response.text.lstrip().lower()
-        return text.startswith('<html') or text.startswith('<!doctype')
+        # Match on the raw leading bytes: decoding response.text means
+        # decoding (and charset-sniffing) the whole body, which is very
+        # slow for large binary responses such as images or PDFs.
+        prefix = response.content[:200]
+        return bool(
+            Browser._HTML_MARKER_RE.match(prefix)
+            # UTF-16/UTF-32 encoded markup, whose ASCII characters are
+            # interleaved with NUL bytes.
+            or Browser._HTML_MARKER_RE.match(prefix.replace(b'\x00', b''))
+        )
 
     @staticmethod
     def add_soup(response, soup_config):

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -54,6 +54,8 @@ class Browser:
 
         self.soup_config = dict(soup_config or ())
 
+    # Regex identifying html-like response content. Allow for optional BOM
+    # (UTF-8, UTF-16 little endian, or UTF-16 big endian) prefix.
     _HTML_MARKER_RE = re.compile(
         rb'\s*(?:\xef\xbb\xbf|\xff\xfe|\xfe\xff)?\s*(?:<html|<!doctype)',
         re.IGNORECASE

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2,6 +2,7 @@ from contextlib import nullcontext
 import os
 import sys
 import tempfile
+from unittest import mock
 
 import pytest
 import setpath  # noqa:F401, must come before 'import mechanicalsoup'
@@ -427,6 +428,43 @@ def test_encoding(httpbin, http_html_expected_encoding):
     )
     browser.open(url)
     assert browser.page.original_encoding == expected_encoding
+
+
+@pytest.mark.parametrize("reply, is_html", [
+    pytest.param(b'<html><body>hi</body></html>', True, id='lowercase'),
+    pytest.param(b'<HTML><BODY>hi</BODY></HTML>', True, id='uppercase'),
+    pytest.param(b'  \n<!DocType html><html></html>', True, id='doctype'),
+    pytest.param('<html><body>hi</body></html>'.encode('utf-16'), True,
+                 id='utf-16'),
+    pytest.param(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR', False, id='png'),
+    pytest.param(b'{"key": "value"}', False, id='json'),
+])
+def test_looks_like_html_without_content_type(reply, is_html):
+    """Detect HTML from the leading bytes when Content-Type is missing."""
+    browser, adapter = prepare_mock_browser()
+    url = 'mock://looks-like-html'
+    mock_get(adapter, url=url, reply=reply, content_type='')
+    response = browser.session.get(url)
+    mechanicalsoup.Browser.add_soup(response, {'features': 'lxml'})
+    assert (response.soup is not None) == is_html
+
+
+def test_looks_like_html_does_not_decode_whole_body():
+    """Content-Type sniffing must not decode the full (possibly huge) body."""
+    browser, adapter = prepare_mock_browser()
+    url = 'mock://binary'
+    mock_get(adapter, url=url, reply=b'\x89PNG\r\n\x1a\n' + os.urandom(4096),
+             content_type='')
+    response = browser.session.get(url)
+
+    def fail_on_decode(self):
+        raise AssertionError("response body should not be decoded")
+
+    monkeypatched = type(response)
+    with mock.patch.object(monkeypatched, 'text', property(fail_on_decode)):
+        mechanicalsoup.Browser.add_soup(response, {'features': 'lxml'})
+
+    assert response.soup is None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #432

`__looks_like_html` decoded the entire response body via `response.text` (which also runs charset sniffing) just to inspect its first few characters, which is slow for large binary responses such as images or PDFs. It now matches a compiled bytes regex against the first 200 bytes of `response.content`, with `re.IGNORECASE` as suggested in the issue — so uppercase markup like `<HTML>` is detected too, which the previous `lower()` only handled after a full decode. NUL bytes are stripped for a second attempt so UTF-16 markup is still recognised.

Tests cover lowercase/uppercase/doctype/UTF-16 markup plus PNG and JSON bodies, and one test asserts `response.text` is never accessed during sniffing (fails on the old implementation, passes on the new one).
