### PR TITLE
Fix some pyright errors

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -3,7 +3,7 @@ import os
 import re
 import tempfile
 from typing import cast
-import urllib
+import urllib.parse
 import weakref
 import webbrowser
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,6 +1,6 @@
 import re
 import sys
-import urllib
+import urllib.parse
 
 import bs4
 import requests
@@ -132,6 +132,11 @@ class StatefulBrowser(Browser):
         ``url``, as in the `.urljoin() method of urllib.parse
         <https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin>`__.
         """
+        if self.url is None:
+            raise AttributeError(
+                "No page has been opened yet on this browser, or the last "
+                "response was not parsed as a page (e.g. it was not HTML)."
+            )
         return urllib.parse.urljoin(self.url, url)
 
     def open(self, url, *args, **kwargs) -> ResponseWithSoup:
@@ -208,8 +213,13 @@ class StatefulBrowser(Browser):
         :return: The selected form as a soup object. It can also be
             retrieved later with the :attr:`form` attribute.
         """
+        if self.page is None:
+            raise AttributeError(
+                "No page has been opened yet on this browser, or the last "
+                "response was not parsed as a page (e.g. it was not HTML)."
+            )
 
-        def find_associated_elements(form_id):
+        def find_associated_elements(form_id, page):
             """Find all elements associated to a form
                 (i.e. an element with a form attribute -> ``form=form_id``)
             """
@@ -223,7 +233,7 @@ class StatefulBrowser(Browser):
 
             for element in elements_with_owner_form:
                 found_elements.extend(
-                    self.page.find_all(element, form=form_id)
+                    page.find_all(element, form=form_id)
                 )
             return found_elements
 
@@ -244,8 +254,7 @@ class StatefulBrowser(Browser):
             form = found_forms[-1]
 
         if form and form.has_attr('id'):
-            form_id = form["id"]
-            new_elements = find_associated_elements(form_id)
+            new_elements = find_associated_elements(form.get("id"), self.page)
             form.extend(new_elements)
 
         self.__state.form = Form(form)
@@ -362,7 +371,7 @@ class StatefulBrowser(Browser):
         * If searching for the link fails and debug is active, launch
           a browser.
         """
-        if hasattr(link, 'attrs') and 'href' in link.attrs:
+        if link and hasattr(link, 'attrs') and 'href' in link.attrs:
             return link
 
         # Check if "link" parameter should be treated as "url_regex"

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -151,6 +151,18 @@ def test_links_no_page():
         browser.links()
 
 
+def test_select_form_no_page():
+    browser = mechanicalsoup.StatefulBrowser()
+    with pytest.raises(AttributeError, match="No page has been opened"):
+        browser.select_form()
+
+
+def test_absolute_url_no_page():
+    browser = mechanicalsoup.StatefulBrowser()
+    with pytest.raises(AttributeError, match="No page has been opened"):
+        browser.absolute_url("foo")
+
+
 @pytest.mark.parametrize("expected_post", [
     pytest.param(
         [


### PR DESCRIPTION
* Pyright requires explicitly importing submodules, so we import `urllib.parse` instead of just `urllib`.

* Some StatefulBrowser methods would implicitly fail if they were called before we set the internal `__state` due to `self.page` and `self.url` being used in a non-None context when they are None (in `select_form` and `absolute_url` respectively). Make these failures explicit so that Pyright understands the failure is expected.

* Pyright was complaining that the literal string "id" could not be used with `bs4.Tag.__getitem__` for its key argument. This is likely a false positive, but switching to `bs4.Tag.get` fixes the error and has the same return value since we have already checked that the "id" attribute exists.

* In `StatefulBrowser.select_form`, Pyright did not remember that the type of `self.page` was narrowed to be not None inside the subfunction `find_associated_elements`. To fix this, simply pass the narrowed `self.page` as an argument to the subfunction.

* The `StatefulBrowser._find_link_internal` method cannot return None, but Pyright seemed to infer that the first conditional could return None. Add an innocuous explicit check against None to make this clear to Pyright.